### PR TITLE
Update the default UPLOAD_CHUNK_SIZE to 100MB.

### DIFF
--- a/google/resumable_media/common.py
+++ b/google/resumable_media/common.py
@@ -22,7 +22,7 @@ _SLEEP_RETRY_ERROR_MSG = (
     u'At most one of `max_cumulative_retry` and `max_retries` '
     u'can be specified.')
 
-UPLOAD_CHUNK_SIZE = 262144  # 256 * 1024
+UPLOAD_CHUNK_SIZE = 104857600  # 100 * 1024 * 1024
 """int: Chunks in a resumable upload must come in multiples of 256 KB."""
 PERMANENT_REDIRECT = 308
 """int: Permanent redirect status code.


### PR DESCRIPTION
The goal here is to lower latency for transfers, as well as having some
consistency between client libraries.

For more discussion, see
https://github.com/google/google-api-python-client/pull/482.

PTAL @dhermes -- I also didn't see an obvious place you were setting a download chunk size, but if you point me at one I'm happy to update it. 😁 