### PR TITLE
Drop a hardcoded value in an error message.

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -319,7 +319,8 @@ class ResumableUpload(UploadBase):
     def __init__(self, upload_url, chunk_size, headers=None):
         super(ResumableUpload, self).__init__(upload_url, headers=headers)
         if chunk_size % resumable_media.UPLOAD_CHUNK_SIZE != 0:
-            raise ValueError(u'256 KB must divide chunk size')
+            raise ValueError(u'{} KB must divide chunk size'.format(
+                resumable_media.UPLOAD_CHUNK_SIZE / 1024))
         self._chunk_size = chunk_size
         self._stream = None
         self._content_type = None


### PR DESCRIPTION
The validation of `ResumableUpload.chunk_size` checks divisibility by a
constant, and then provides an error with a hardcoded value for that constant.
This can be confusing (eg #47).

The fix here is to just insert the appropriate value into the error message.
Adding a bad value still gives the expected error message, eg

```
Traceback (most recent call last):
  File "/usr/local/google/home/craigcitro/gh/google-resumable-media-python/tests/unit/test__upload.py", line 245, in test_constructor
    upload = _upload.ResumableUpload(RESUMABLE_URL, 12 * 1024)#chunk_size)
  File "/usr/local/google/home/craigcitro/gh/google-resumable-media-python/google/resumable_media/_upload.py", line 323, in __init__
    resumable_media.UPLOAD_CHUNK_SIZE / 1024))
ValueError: 256 KB must divide chunk size
```

PTAL @dhermes 