### PR TITLE
deflate-encoded content will fail md5 checksum

### DIFF
--- a/scripts/rewrite_index_rst.py
+++ b/scripts/rewrite_index_rst.py
@@ -42,10 +42,10 @@ _EXPECTED_SUBMODULE_LINES = (
 _EXPECTED_AUTOMODULE_LINES = (
     '',
     '.. automodule:: google.resumable_media',
-    '    :members:',
-    '    :inherited-members:',
-    '    :undoc-members:',
-    '    :show-inheritance:',
+    '   :members:',
+    '   :inherited-members:',
+    '   :undoc-members:',
+    '   :show-inheritance:',
     '',
 )
 _CURR_DIR = os.path.dirname(__file__)
@@ -102,7 +102,7 @@ def main():
                     if set(line) == set('=')]
     if title_index != 1:
         raise ValueError('Unexpected title line', title_index)
-    if lines[0] != 'google\.resumable\_media package':
+    if lines[0] != 'google.resumable\_media package':
         raise ValueError('Unexpected title content', lines[0])
 
     title = '``google.resumable_media``'

--- a/scripts/rewrite_requests_pkg_rst.py
+++ b/scripts/rewrite_requests_pkg_rst.py
@@ -34,10 +34,10 @@ _BASE_PACKAGE = 'google.resumable_media.requests'
 _EXPECTED_AUTOMODULE_LINES = (
     '',
     '.. automodule:: google.resumable_media.requests',
-    '    :members:',
-    '    :inherited-members:',
-    '    :undoc-members:',
-    '    :show-inheritance:',
+    '   :members:',
+    '   :inherited-members:',
+    '   :undoc-members:',
+    '   :show-inheritance:',
     '',
 )
 _CURR_DIR = os.path.dirname(__file__)
@@ -93,7 +93,7 @@ def main():
                     if set(line) == set('=')]
     if title_index != 1:
         raise ValueError('Unexpected title line', title_index)
-    if lines[0] != 'google\.resumable\_media\.requests package':
+    if lines[0] != 'google.resumable\_media.requests package':
         raise ValueError('Unexpected title content', lines[0])
 
     title = '``google.resumable_media.requests``'


### PR DESCRIPTION
Added decoder for deflate in gzip's decoder fashion
https://github.com/googleapis/google-resumable-media-python/issues/37