### PR TITLE
DRY 'requests' pin; don't shadow exception.

### DIFF
--- a/google/resumable_media/requests/__init__.py
+++ b/google/resumable_media/requests/__init__.py
@@ -658,19 +658,9 @@ transmitted in chunks until completion:
    >>> json_response[u'name'] == blob_name
    True
 """
-
 import pkg_resources
 
-try:
-    pkg_resources.require('requests >= 2.18.0')
-except pkg_resources.ResolutionError as caught_exc:  # pragma: NO COVER
-    import six
-    new_exc = ImportError(
-        '``requests >= 2.18.0`` is required by the '
-        '``google.resumable_media.requests`` subpackage.\n'
-        'It can be installed via\n'
-        '    pip install google-resumable-media[requests].')
-    six.raise_from(new_exc, caught_exc)
+pkg_resources.require('google-resumable-media[requests]')  # noqa: E402
 
 from google.resumable_media.requests.download import ChunkedDownload
 from google.resumable_media.requests.download import Download


### PR DESCRIPTION
Supersedes PR #70.

Closes #58.