### PR TITLE
Always use raw response data.

### DIFF
--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -343,18 +343,30 @@ class ChunkedDownload(DownloadBase):
         _helpers.require_status_code(
             response, _ACCEPTABLE_STATUS_CODES,
             self._get_status_code, callback=self._make_invalid)
-        content_length = _helpers.header_required(
-            response, u'content-length', self._get_headers,
-            callback=self._make_invalid)
-        num_bytes = int(content_length)
-        _, end_byte, total_bytes = get_range_info(
-            response, self._get_headers, callback=self._make_invalid)
+        headers = self._get_headers(response)
         response_body = self._get_body(response)
-        if len(response_body) != num_bytes:
-            self._make_invalid()
-            raise common.InvalidResponse(
-                response, u'Response is different size than content-length',
-                u'Expected', num_bytes, u'Received', len(response_body))
+
+        start_byte, end_byte, total_bytes = get_range_info(
+            response, self._get_headers, callback=self._make_invalid)
+
+        transfer_encoding = headers.get(u'transfer-encoding')
+
+        if transfer_encoding is None:
+            content_length = _helpers.header_required(
+                response, u'content-length', self._get_headers,
+                callback=self._make_invalid)
+            num_bytes = int(content_length)
+            if len(response_body) != num_bytes:
+                self._make_invalid()
+                raise common.InvalidResponse(
+                    response,
+                    u'Response is different size than content-length',
+                    u'Expected', num_bytes,
+                    u'Received', len(response_body),
+                )
+        else:
+            # 'content-length' header not allowed with chunked encoding.
+            num_bytes = end_byte - start_byte + 1
 
         # First update ``bytes_downloaded``.
         self._bytes_downloaded += num_bytes

--- a/google/resumable_media/requests/_helpers.py
+++ b/google/resumable_media/requests/_helpers.py
@@ -25,6 +25,7 @@ from google.resumable_media import common
 
 
 _DEFAULT_RETRY_STRATEGY = common.RetryStrategy()
+_SINGLE_GET_CHUNK_SIZE = 8192
 
 
 class RequestsMixin(object):
@@ -69,7 +70,12 @@ class RequestsMixin(object):
         Returns:
             bytes: The body of the ``response``.
         """
-        return response.content
+        if response._content is False:
+            response._content = b''.join(
+                response.raw.stream(
+                    _SINGLE_GET_CHUNK_SIZE, decode_content=False))
+            response._content_consumed = True
+        return response._content
 
 
 def http_request(transport, method, url, data=None, headers=None,

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -18,15 +18,12 @@ import base64
 import hashlib
 import logging
 
-import urllib3.response
-
 from google.resumable_media import _download
 from google.resumable_media import common
 from google.resumable_media.requests import _helpers
 
 
 _LOGGER = logging.getLogger(__name__)
-_SINGLE_GET_CHUNK_SIZE = 8192
 _HASH_HEADER = u'x-goog-hash'
 _MISSING_MD5 = u"""\
 No MD5 checksum was returned from the service while downloading {}
@@ -117,12 +114,12 @@ class Download(_helpers.RequestsMixin, _download.Download):
         with response:
             # NOTE: This might "donate" ``md5_hash`` to the decoder and replace
             #       it with a ``_DoNothingHash``.
-            local_hash = _add_decoder(response.raw, md5_hash)
-            body_iter = response.iter_content(
-                chunk_size=_SINGLE_GET_CHUNK_SIZE, decode_unicode=False)
+            body_iter = response.raw.stream(
+                _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
             for chunk in body_iter:
                 self._stream.write(chunk)
-                local_hash.update(chunk)
+                md5_hash.update(chunk)
+            response._content_consumed = True
 
         if expected_md5_hash is None:
             return
@@ -157,16 +154,15 @@ class Download(_helpers.RequestsMixin, _download.Download):
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        request_kwargs = {
-            u'data': payload,
-            u'headers': headers,
-            u'retry_strategy': self._retry_strategy,
-        }
-        if self._stream is not None:
-            request_kwargs[u'stream'] = True
-
         result = _helpers.http_request(
-            transport, method, url, **request_kwargs)
+            transport,
+            method,
+            url,
+            data=payload,
+            headers=headers,
+            retry_strategy=self._retry_strategy,
+            stream=True,
+        )
 
         self._process_response(result)
 
@@ -221,7 +217,7 @@ class ChunkedDownload(_helpers.RequestsMixin, _download.ChunkedDownload):
         # NOTE: We assume "payload is None" but pass it along anyway.
         result = _helpers.http_request(
             transport, method, url, data=payload, headers=headers,
-            retry_strategy=self._retry_strategy)
+            retry_strategy=self._retry_strategy, stream=True)
         self._process_response(result)
         return result
 
@@ -291,58 +287,3 @@ class _DoNothingHash(object):
         Args:
             unused_chunk (bytes): A chunk of data.
         """
-
-
-def _add_decoder(response_raw, md5_hash):
-    """Patch the ``_decoder`` on a ``urllib3`` response.
-
-    This is so that we can intercept the compressed bytes before they are
-    decoded.
-
-    Only patches if the content encoding is ``gzip``.
-
-    Args:
-        response_raw (urllib3.response.HTTPResponse): The raw response for
-            an HTTP request.
-        md5_hash (Union[_DoNothingHash, hashlib.md5]): A hash function which
-            will get updated when it encounters compressed bytes.
-
-    Returns:
-        Union[_DoNothingHash, hashlib.md5]: Either the original ``md5_hash``
-        if ``_decoder`` is not patched. Otherwise, returns a ``_DoNothingHash``
-        since the caller will no longer need to hash to decoded bytes.
-    """
-    encoding = response_raw.headers.get(u'content-encoding', u'').lower()
-    if encoding != u'gzip':
-        return md5_hash
-
-    response_raw._decoder = _GzipDecoder(md5_hash)
-    return _DoNothingHash()
-
-
-class _GzipDecoder(urllib3.response.GzipDecoder):
-    """Custom subclass of ``urllib3`` decoder for ``gzip``-ed bytes.
-
-    Allows an MD5 hash function to see the compressed bytes before they are
-    decoded. This way the hash of the compressed value can be computed.
-
-    Args:
-        md5_hash (Union[_DoNothingHash, hashlib.md5]): A hash function which
-            will get updated when it encounters compressed bytes.
-    """
-
-    def __init__(self, md5_hash):
-        super(_GzipDecoder, self).__init__()
-        self._md5_hash = md5_hash
-
-    def decompress(self, data):
-        """Decompress the bytes.
-
-        Args:
-            data (bytes): The compressed bytes to be decompressed.
-
-        Returns:
-            bytes: The decompressed bytes from ``data``.
-        """
-        self._md5_hash.update(data)
-        return super(_GzipDecoder, self).decompress(data)

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ REQUESTS = 'requests >= 2.18.0, < 3.0.0dev'
 GOOGLE_AUTH = 'google-auth >= 0.10.0'
 
 
-@nox.session(python=['2,7', '3.4', '3.5', '3.6', '3.7'])
+@nox.session(python=['2.7', '3.4', '3.5', '3.6', '3.7'])
 def unit_tests(session):
     """Run the unit test suite."""
 

--- a/tests/unit/requests/test__helpers.py
+++ b/tests/unit/requests/test__helpers.py
@@ -27,12 +27,21 @@ class TestRequestsMixin(object):
 
     def test__get_headers(self):
         headers = {u'fruit': u'apple'}
-        response = mock.Mock(headers=headers, spec=[u'headers'])
+        response = mock.Mock(headers=headers, spec=['headers'])
         assert headers == _helpers.RequestsMixin._get_headers(response)
 
-    def test__get_body(self):
+    def test__get_body_wo_content_consumed(self):
         body = b'This is the payload.'
-        response = mock.Mock(content=body, spec=[u'content'])
+        raw = mock.Mock(spec=['stream'])
+        raw.stream.return_value = iter([body])
+        response = mock.Mock(raw=raw, _content=False, spec=['raw', '_content'])
+        assert body == _helpers.RequestsMixin._get_body(response)
+        raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
+
+    def test__get_body_w_content_consumed(self):
+        body = b'This is the payload.'
+        response = mock.Mock(_content=body, spec=['_content'])
         assert body == _helpers.RequestsMixin._get_body(response)
 
 

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -19,7 +19,8 @@ import pytest
 from six.moves import http_client
 
 from google.resumable_media import common
-import google.resumable_media.requests.download as download_mod
+from google.resumable_media.requests import download as download_mod
+from google.resumable_media.requests import _helpers
 
 
 EXAMPLE_URL = (
@@ -29,7 +30,7 @@ EXAMPLE_URL = (
 
 class TestDownload(object):
 
-    @mock.patch(u'google.resumable_media.requests.download._LOGGER')
+    @mock.patch('google.resumable_media.requests.download._LOGGER')
     def test__get_expected_md5_present(self, _LOGGER):
         download = download_mod.Download(EXAMPLE_URL)
 
@@ -42,7 +43,7 @@ class TestDownload(object):
         assert expected_md5_hash == checksum
         _LOGGER.info.assert_not_called()
 
-    @mock.patch(u'google.resumable_media.requests.download._LOGGER')
+    @mock.patch('google.resumable_media.requests.download._LOGGER')
     def test__get_expected_md5_missing(self, _LOGGER):
         download = download_mod.Download(EXAMPLE_URL)
 
@@ -70,9 +71,8 @@ class TestDownload(object):
         # Check mocks.
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
-        response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE,
-            decode_unicode=False)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
 
     def test__write_to_stream_with_hash_check_success(self):
         stream = io.BytesIO()
@@ -94,9 +94,8 @@ class TestDownload(object):
         # Check mocks.
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
-        response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE,
-            decode_unicode=False)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
 
     def test__write_to_stream_with_hash_check_fail(self):
         stream = io.BytesIO()
@@ -127,16 +126,15 @@ class TestDownload(object):
         # Check mocks.
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
-        response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE,
-            decode_unicode=False)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
 
     def _consume_helper(
             self, stream=None, end=65536, headers=None, chunks=(),
             response_headers=None):
         download = download_mod.Download(
             EXAMPLE_URL, stream=stream, end=end, headers=headers)
-        transport = mock.Mock(spec=[u'request'])
+        transport = mock.Mock(spec=['request'])
         transport.request.return_value = _mock_response(
             chunks=chunks, headers=response_headers)
 
@@ -144,12 +142,16 @@ class TestDownload(object):
         ret_val = download.consume(transport)
         assert ret_val is transport.request.return_value
 
-        called_kwargs = {u'data': None, u'headers': download._headers}
         if chunks:
             assert stream is not None
-            called_kwargs[u'stream'] = True
+
         transport.request.assert_called_once_with(
-            u'GET', EXAMPLE_URL, **called_kwargs)
+            u'GET',
+            EXAMPLE_URL,
+            data=None,
+            headers=download._headers,
+            stream=True,
+        )
 
         range_bytes = u'bytes={:d}-{:d}'.format(0, end)
         assert download._headers[u'range'] == range_bytes
@@ -171,9 +173,8 @@ class TestDownload(object):
         response = transport.request.return_value
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
-        response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE,
-            decode_unicode=False)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
 
     def test_consume_with_stream_hash_check_success(self):
         stream = io.BytesIO()
@@ -189,9 +190,8 @@ class TestDownload(object):
         response = transport.request.return_value
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
-        response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE,
-            decode_unicode=False)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
 
     def test_consume_with_stream_hash_check_fail(self):
         stream = io.BytesIO()
@@ -202,7 +202,7 @@ class TestDownload(object):
         bad_checksum = u'anVzdCBub3QgdGhpcyAxLA=='
         header_value = u'crc32c=V0FUPw==,md5={}'.format(bad_checksum)
         headers = {download_mod._HASH_HEADER: header_value}
-        transport = mock.Mock(spec=[u'request'])
+        transport = mock.Mock(spec=['request'])
         transport.request.return_value = _mock_response(
             chunks=chunks, headers=headers)
 
@@ -256,11 +256,11 @@ class TestChunkedDownload(object):
         response_headers = self._response_headers(
             start_byte, end_byte, total_bytes)
         return mock.Mock(
-            content=content,
+            _content=content,
             headers=response_headers,
             status_code=status_code,
             spec=[
-                u'content',
+                u'_content',
                 u'headers',
                 u'status_code',
             ],
@@ -273,7 +273,7 @@ class TestChunkedDownload(object):
             download.consume_next_chunk(None)
 
     def _mock_transport(self, start, chunk_size, total_bytes, content=b''):
-        transport = mock.Mock(spec=[u'request'])
+        transport = mock.Mock(spec=['request'])
         assert len(content) == chunk_size
         transport.request.return_value = self._mock_response(
             start, start + chunk_size - 1, total_bytes,
@@ -302,7 +302,12 @@ class TestChunkedDownload(object):
         range_bytes = u'bytes={:d}-{:d}'.format(start, start + chunk_size - 1)
         download_headers = {u'range': range_bytes}
         transport.request.assert_called_once_with(
-            u'GET', EXAMPLE_URL, data=None, headers=download_headers)
+            u'GET',
+            EXAMPLE_URL,
+            data=None,
+            headers=download_headers,
+            stream=True,
+        )
         assert stream.getvalue() == data
         # Go back and check the internal state after consuming the chunk.
         assert not download.finished
@@ -362,75 +367,36 @@ def test__DoNothingHash():
     assert return_value is None
 
 
-class Test__add_decoder(object):
-
-    def test_non_gzipped(self):
-        response_raw = mock.Mock(headers={}, spec=[u'headers'])
-        md5_hash = download_mod._add_decoder(
-            response_raw, mock.sentinel.md5_hash)
-
-        assert md5_hash is mock.sentinel.md5_hash
-
-    def test_gzipped(self):
-        headers = {u'content-encoding': u'gzip'}
-        response_raw = mock.Mock(
-            headers=headers, spec=[u'headers', u'_decoder'])
-        md5_hash = download_mod._add_decoder(
-            response_raw, mock.sentinel.md5_hash)
-
-        assert md5_hash is not mock.sentinel.md5_hash
-        assert isinstance(md5_hash, download_mod._DoNothingHash)
-        assert isinstance(response_raw._decoder, download_mod._GzipDecoder)
-        assert response_raw._decoder._md5_hash is mock.sentinel.md5_hash
-
-
-class Test_GzipDecoder(object):
-
-    def test_constructor(self):
-        decoder = download_mod._GzipDecoder(mock.sentinel.md5_hash)
-        assert decoder._md5_hash is mock.sentinel.md5_hash
-
-    def test_decompress(self):
-        md5_hash = mock.Mock(spec=['update'])
-        decoder = download_mod._GzipDecoder(md5_hash)
-
-        data = b'\x1f\x8b\x08\x08'
-        result = decoder.decompress(data)
-
-        assert result == b''
-        md5_hash.update.assert_called_once_with(data)
-
-
 def _mock_response(status_code=http_client.OK, chunks=(), headers=None):
     if headers is None:
         headers = {}
 
     if chunks:
-        mock_raw = mock.Mock(headers=headers, spec=[u'headers'])
+        mock_raw = mock.Mock(headers=headers, spec=['headers', 'stream'])
+        mock_raw.stream.return_value = iter(chunks)
         response = mock.MagicMock(
             headers=headers,
             status_code=int(status_code),
             raw=mock_raw,
             spec=[
-                u'__enter__',
-                u'__exit__',
-                u'iter_content',
-                u'status_code',
-                u'headers',
-                u'raw',
+                '__enter__',
+                '__exit__',
+                'raw',
+                'status_code',
+                'headers',
+                'raw',
             ],
         )
         # i.e. context manager returns ``self``.
         response.__enter__.return_value = response
         response.__exit__.return_value = None
-        response.iter_content.return_value = iter(chunks)
         return response
     else:
         return mock.Mock(
             headers=headers,
             status_code=int(status_code),
             spec=[
-                u'status_code',
-                u'headers',
+                'status_code',
+                'headers',
             ],
         )


### PR DESCRIPTION
Don't expect contra-spec `Content-Length` header for chunked downloads.

Re-enable Python 2.7 unit tests.

Closes #37
Closes #49
Closes #50
Closes #56
Closes #76