### PR TITLE
feat: add raw download classes

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -14,7 +14,9 @@
 
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/google/resumable_media/requests/__init__.py
+++ b/google/resumable_media/requests/__init__.py
@@ -661,6 +661,7 @@ transmitted in chunks until completion:
 from google.resumable_media.requests.download import ChunkedDownload
 from google.resumable_media.requests.download import Download
 from google.resumable_media.requests.upload import MultipartUpload
+from google.resumable_media.requests.download import RawDownload
 from google.resumable_media.requests.upload import ResumableUpload
 from google.resumable_media.requests.upload import SimpleUpload
 
@@ -669,6 +670,7 @@ __all__ = [
     u"ChunkedDownload",
     u"Download",
     u"MultipartUpload",
+    u"RawDownload",
     u"ResumableUpload",
     u"SimpleUpload",
 ]

--- a/google/resumable_media/requests/__init__.py
+++ b/google/resumable_media/requests/__init__.py
@@ -661,6 +661,7 @@ transmitted in chunks until completion:
 from google.resumable_media.requests.download import ChunkedDownload
 from google.resumable_media.requests.download import Download
 from google.resumable_media.requests.upload import MultipartUpload
+from google.resumable_media.requests.download import RawChunkedDownload
 from google.resumable_media.requests.download import RawDownload
 from google.resumable_media.requests.upload import ResumableUpload
 from google.resumable_media.requests.upload import SimpleUpload
@@ -670,6 +671,7 @@ __all__ = [
     u"ChunkedDownload",
     u"Download",
     u"MultipartUpload",
+    u"RawChunkedDownload",
     u"RawDownload",
     u"ResumableUpload",
     u"SimpleUpload",

--- a/google/resumable_media/requests/__init__.py
+++ b/google/resumable_media/requests/__init__.py
@@ -78,12 +78,12 @@ access to the resource:
    fake_response = requests.Response()
    fake_response.status_code = int(http_client.OK)
    fake_response.headers[u'Content-Length'] = u'1364156'
-   fake_content = mock.MagicMock(spec=[u'__len__'])
+   fake_content = mock.MagicMock(spec=['__len__'])
    fake_content.__len__.return_value = 1364156
    fake_response._content = fake_content
 
    get_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=get_method, spec=[u'request'])
+   transport = mock.Mock(request=get_method, spec=['request'])
 
 .. doctest:: basic-download
 
@@ -127,12 +127,12 @@ specify ``start`` and ``end`` byte positions (both optional):
    fake_response.headers[u'Content-Length'] = u'{:d}'.format(slice_size)
    content_range = u'bytes {:d}-{:d}/1364156'.format(start, end)
    fake_response.headers[u'Content-Range'] = content_range
-   fake_content = mock.MagicMock(spec=[u'__len__'])
+   fake_content = mock.MagicMock(spec=['__len__'])
    fake_content.__len__.return_value = slice_size
    fake_response._content = fake_content
 
    get_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=get_method, spec=[u'request'])
+   transport = mock.Mock(request=get_method, spec=['request'])
 
 .. doctest:: basic-download-with-slice
 
@@ -188,7 +188,7 @@ having to fit in memory all at once.
    fake_response._content = fake_content
 
    get_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=get_method, spec=[u'request'])
+   transport = mock.Mock(request=get_method, spec=['request'])
 
 .. doctest:: chunked-download
 
@@ -240,7 +240,7 @@ not be the same size as the other chunks:
 
    fifty_mb = 50 * 1024 * 1024
    one_gb = 1024 * 1024 * 1024
-   stream = mock.Mock(spec=[u'write'])
+   stream = mock.Mock(spec=['write'])
    download = ChunkedDownload(media_url, fifty_mb, stream)
    download._bytes_downloaded = 20 * fifty_mb
    download._total_bytes = one_gb
@@ -252,12 +252,12 @@ not be the same size as the other chunks:
    content_range = u'bytes {:d}-{:d}/{:d}'.format(
        20 * fifty_mb, one_gb - 1, one_gb)
    fake_response.headers[u'Content-Range'] = content_range
-   fake_content = mock.MagicMock(spec=[u'__len__'])
+   fake_content = mock.MagicMock(spec=['__len__'])
    fake_content.__len__.return_value = slice_size
    fake_response._content = fake_content
 
    get_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=get_method, spec=[u'request'])
+   transport = mock.Mock(request=get_method, spec=['request'])
 
 .. doctest:: chunked-download-end
 
@@ -318,7 +318,7 @@ associated with the resource.
    fake_response._content = json.dumps(payload).encode(u'utf-8')
 
    post_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=post_method, spec=[u'request'])
+   transport = mock.Mock(request=post_method, spec=['request'])
 
 .. doctest:: simple-upload
    :options: +NORMALIZE_WHITESPACE
@@ -375,7 +375,7 @@ will be raised:
    fake_response.status_code = int(http_client.SERVICE_UNAVAILABLE)
 
    post_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=post_method, spec=[u'request'])
+   transport = mock.Mock(request=post_method, spec=['request'])
 
    time_sleep = time.sleep
    def dont_sleep(seconds):
@@ -453,7 +453,7 @@ accepts an extra required argument: ``metadata``.
    fake_response._content = json.dumps(payload).encode(u'utf-8')
 
    post_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=post_method, spec=[u'request'])
+   transport = mock.Mock(request=post_method, spec=['request'])
 
 .. doctest:: multipart-upload
 
@@ -542,7 +542,7 @@ object or any other stream implementing the same interface.
    fake_response.headers[u'x-guploader-uploadid'] = upload_id
 
    post_method = mock.Mock(return_value=fake_response, spec=[])
-   transport = mock.Mock(request=post_method, spec=[u'request'])
+   transport = mock.Mock(request=post_method, spec=['request'])
 
 .. doctest:: resumable-initiate
 
@@ -625,7 +625,7 @@ transmitted in chunks until completion:
    # Use the fake responses to mock a transport.
    responses = [fake_response0, fake_response1, fake_response2]
    put_method = mock.Mock(side_effect=responses, spec=[])
-   transport = mock.Mock(request=put_method, spec=[u'request'])
+   transport = mock.Mock(request=put_method, spec=['request'])
 
 .. doctest:: resumable-transmit
 

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -26,7 +26,6 @@ from google.resumable_media.requests import _helpers
 
 
 _LOGGER = logging.getLogger(__name__)
-_SINGLE_GET_CHUNK_SIZE = 8192
 _HASH_HEADER = u"x-goog-hash"
 _MISSING_MD5 = u"""\
 No MD5 checksum was returned from the service while downloading {}
@@ -101,7 +100,7 @@ class Download(_helpers.RequestsMixin, _download.Download):
             #       it with a ``_DoNothingHash``.
             local_hash = _add_decoder(response.raw, md5_hash)
             body_iter = response.iter_content(
-                chunk_size=_SINGLE_GET_CHUNK_SIZE, decode_unicode=False
+                chunk_size=_helpers._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
             )
             for chunk in body_iter:
                 self._stream.write(chunk)
@@ -150,6 +149,118 @@ class Download(_helpers.RequestsMixin, _download.Download):
             request_kwargs[u"stream"] = True
 
         result = _helpers.http_request(transport, method, url, **request_kwargs)
+
+        self._process_response(result)
+
+        if self._stream is not None:
+            self._write_to_stream(result)
+
+        return result
+
+
+class RawDownload(_helpers.RawRequestsMixin, _download.Download):
+    """Helper to manage downloading a raw resource from a Google API.
+
+    "Slices" of the resource can be retrieved by specifying a range
+    with ``start`` and / or ``end``. However, in typical usage, neither
+    ``start`` nor ``end`` is expected to be provided.
+
+    Args:
+        media_url (str): The URL containing the media to be downloaded.
+        stream (IO[bytes]): A write-able stream (i.e. file-like object) that
+            the downloaded resource can be written to.
+        start (int): The first byte in a range to be downloaded. If not
+            provided, but ``end`` is provided, will download from the
+            beginning to ``end`` of the media.
+        end (int): The last byte in a range to be downloaded. If not
+            provided, but ``start`` is provided, will download from the
+            ``start`` to the end of the media.
+        headers (Optional[Mapping[str, str]]): Extra headers that should
+            be sent with the request, e.g. headers for encrypted data.
+
+    Attributes:
+        media_url (str): The URL containing the media to be downloaded.
+        start (Optional[int]): The first byte in a range to be downloaded.
+        end (Optional[int]): The last byte in a range to be downloaded.
+    """
+
+    def _write_to_stream(self, response):
+        """Write response body to a write-able stream.
+
+        .. note:
+
+            This method assumes that the ``_stream`` attribute is set on the
+            current download.
+
+        Args:
+            response (~requests.Response): The HTTP response object.
+
+        Raises:
+            ~google.resumable_media.common.DataCorruption: If the download's
+                checksum doesn't agree with server-computed checksum.
+        """
+        expected_md5_hash = _get_expected_md5(
+            response, self._get_headers, self.media_url
+        )
+
+        if expected_md5_hash is None:
+            md5_hash = _DoNothingHash()
+        else:
+            md5_hash = hashlib.md5()
+        with response:
+            # NOTE: This might "donate" ``md5_hash`` to the decoder and replace
+            #       it with a ``_DoNothingHash``.
+            body_iter = response.raw.stream(
+                _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+            )
+            for chunk in body_iter:
+                self._stream.write(chunk)
+                md5_hash.update(chunk)
+            response._content_consumed = True
+
+        if expected_md5_hash is None:
+            return
+
+        actual_md5_hash = base64.b64encode(md5_hash.digest())
+        # NOTE: ``b64encode`` returns ``bytes``, but ``expected_md5_hash``
+        #       came from a header, so it will be ``str``.
+        actual_md5_hash = actual_md5_hash.decode(u"utf-8")
+        if actual_md5_hash != expected_md5_hash:
+            msg = _CHECKSUM_MISMATCH.format(
+                self.media_url, expected_md5_hash, actual_md5_hash
+            )
+            raise common.DataCorruption(response, msg)
+
+    def consume(self, transport):
+        """Consume the resource to be downloaded.
+
+        If a ``stream`` is attached to this download, then the downloaded
+        resource will be written to the stream.
+
+        Args:
+            transport (~requests.Session): A ``requests`` object which can
+                make authenticated requests.
+
+        Returns:
+            ~requests.Response: The HTTP response returned by ``transport``.
+
+        Raises:
+            ~google.resumable_media.common.DataCorruption: If the download's
+                checksum doesn't agree with server-computed checksum.
+            ValueError: If the current :class:`Download` has already
+                finished.
+        """
+        method, url, payload, headers = self._prepare_request()
+        # NOTE: We assume "payload is None" but pass it along anyway.
+        result = _helpers.http_request(
+            transport,
+            method,
+            url,
+            data=payload,
+            headers=headers,
+            retry_strategy=self._retry_strategy,
+            stream=True,
+        )
 
         self._process_response(result)
 

--- a/google/resumable_media/requests/upload.py
+++ b/google/resumable_media/requests/upload.py
@@ -169,7 +169,7 @@ class ResumableUpload(_helpers.RequestsMixin, _upload.ResumableUpload):
        fake_response.headers[u'location'] = resumable_url
 
        post_method = mock.Mock(return_value=fake_response, spec=[])
-       transport = mock.Mock(request=post_method, spec=[u'request'])
+       transport = mock.Mock(request=post_method, spec=['request'])
 
     .. doctest:: resumable-explicit-size
 
@@ -219,7 +219,7 @@ class ResumableUpload(_helpers.RequestsMixin, _upload.ResumableUpload):
        fake_response.headers[u'location'] = resumable_url
 
        post_method = mock.Mock(return_value=fake_response, spec=[])
-       transport = mock.Mock(request=post_method, spec=[u'request'])
+       transport = mock.Mock(request=post_method, spec=['request'])
 
        data = b'some MOAR bytes!'
        metadata = {u'name': u'some-file.jpg'}
@@ -260,7 +260,7 @@ class ResumableUpload(_helpers.RequestsMixin, _upload.ResumableUpload):
        fake_response.headers[u'location'] = resumable_url
 
        post_method = mock.Mock(return_value=fake_response, spec=[])
-       transport = mock.Mock(request=post_method, spec=[u'request'])
+       transport = mock.Mock(request=post_method, spec=['request'])
 
        metadata = {u'name': u'some-file.jpg'}
        content_type = u'application/octet-stream'
@@ -375,7 +375,7 @@ class ResumableUpload(_helpers.RequestsMixin, _upload.ResumableUpload):
            from google import resumable_media
            import google.resumable_media.requests.upload as upload_mod
 
-           transport = mock.Mock(spec=[u'request'])
+           transport = mock.Mock(spec=['request'])
            fake_response = requests.Response()
            fake_response.status_code = int(http_client.BAD_REQUEST)
            transport.request.return_value = fake_response

--- a/tests/system/requests/test_download.py
+++ b/tests/system/requests/test_download.py
@@ -40,9 +40,40 @@ NOT_FOUND_ERR = (
 )
 
 
+class CorruptingAuthorizedSession(tr_requests.AuthorizedSession):
+    """A Requests Session class with credentials, which corrupts responses.
+
+    This class is used for testing checksum validation.
+
+    Args:
+        credentials (google.auth.credentials.Credentials): The credentials to
+            add to the request.
+        refresh_status_codes (Sequence[int]): Which HTTP status codes indicate
+            that credentials should be refreshed and the request should be
+            retried.
+        max_refresh_attempts (int): The maximum number of times to attempt to
+            refresh the credentials and retry the request.
+        kwargs: Additional arguments passed to the :class:`requests.Session`
+            constructor.
+    """
+
+    EMPTY_HASH = base64.b64encode(hashlib.md5(b"").digest()).decode(u"utf-8")
+
+    def request(self, method, url, data=None, headers=None, **kwargs):
+        """Implementation of Requests' request."""
+        response = tr_requests.AuthorizedSession.request(
+            self, method, url, data=data, headers=headers, **kwargs
+        )
+        response.headers[download_mod._HASH_HEADER] = u"md5={}".format(self.EMPTY_HASH)
+        return response
+
+
+def get_path(filename):
+    return os.path.realpath(os.path.join(DATA_DIR, filename))
+
 ALL_FILES = (
     {
-        u"path": os.path.realpath(os.path.join(DATA_DIR, u"image1.jpg")),
+        u"path": get_path(u"image1.jpg"),
         u"content_type": IMAGE_JPEG,
         u"checksum": u"1bsd83IYNug8hd+V1ING3Q==",
         u"slices": (
@@ -53,7 +84,7 @@ ALL_FILES = (
         ),
     },
     {
-        u"path": os.path.realpath(os.path.join(DATA_DIR, u"image2.jpg")),
+        u"path": get_path(u"image2.jpg"),
         u"content_type": IMAGE_JPEG,
         u"checksum": u"gdLXJltiYAMP9WZZFEQI1Q==",
         u"slices": (
@@ -64,14 +95,14 @@ ALL_FILES = (
         ),
     },
     {
-        u"path": os.path.realpath(os.path.join(DATA_DIR, u"file.txt")),
+        u"path": get_path(u"file.txt"),
         u"content_type": PLAIN_TEXT,
         u"checksum": u"KHRs/+ZSrc/FuuR4qz/PZQ==",
         u"slices": (),
     },
     {
-        u"path": os.path.realpath(os.path.join(DATA_DIR, u"gzipped.txt.gz")),
-        u"uncompressed": os.path.realpath(os.path.join(DATA_DIR, u"gzipped.txt")),
+        u"path": get_path(u"gzipped.txt.gz"),
+        u"uncompressed": get_path(u"gzipped.txt"),
         u"content_type": PLAIN_TEXT,
         u"checksum": u"KHRs/+ZSrc/FuuR4qz/PZQ==",
         u"slices": (),
@@ -169,7 +200,6 @@ def add_files(authorized_transport, bucket):
     for blob_name in blob_names:
         delete_blob(authorized_transport, blob_name)
 
-
 def check_tombstoned(download, transport):
     assert download.finished
     if isinstance(download, resumable_requests.Download):
@@ -193,168 +223,142 @@ def check_error_response(exc_info, status_code, message):
     assert error.args[4] == http_client.PARTIAL_CONTENT
 
 
-class CorruptingAuthorizedSession(tr_requests.AuthorizedSession):
-    """A Requests Session class with credentials, which corrupts responses.
+class TestDownload(object):
 
-    This class is used for testing checksum validation.
+    @staticmethod
+    def _get_target_class():
+        return resumable_requests.Download
 
-    Args:
-        credentials (google.auth.credentials.Credentials): The credentials to
-            add to the request.
-        refresh_status_codes (Sequence[int]): Which HTTP status codes indicate
-            that credentials should be refreshed and the request should be
-            retried.
-        max_refresh_attempts (int): The maximum number of times to attempt to
-            refresh the credentials and retry the request.
-        kwargs: Additional arguments passed to the :class:`requests.Session`
-            constructor.
-    """
+    def _make_one(self, media_url, **kw):
+        return self._get_target_class()(media_url, **kw)
 
-    EMPTY_HASH = base64.b64encode(hashlib.md5(b"").digest()).decode(u"utf-8")
+    def test_download_full(self, add_files, authorized_transport):
+        for info in ALL_FILES:
+            actual_contents = get_contents(info)
+            blob_name = get_blob_name(info)
 
-    def request(self, method, url, data=None, headers=None, **kwargs):
-        """Implementation of Requests' request."""
-        response = tr_requests.AuthorizedSession.request(
-            self, method, url, data=data, headers=headers, **kwargs
-        )
-        response.headers[download_mod._HASH_HEADER] = u"md5={}".format(self.EMPTY_HASH)
-        return response
-
-
-def test_download_full(add_files, authorized_transport):
-    for info in ALL_FILES:
-        actual_contents = get_contents(info)
-        blob_name = get_blob_name(info)
-
-        # Create the actual download object.
-        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-        download = resumable_requests.Download(media_url)
-        # Consume the resource.
-        response = download.consume(authorized_transport)
-        assert response.status_code == http_client.OK
-        assert response.content == actual_contents
-        check_tombstoned(download, authorized_transport)
-
-
-def test_download_to_stream(add_files, authorized_transport):
-    for info in ALL_FILES:
-        actual_contents = get_contents(info)
-        blob_name = get_blob_name(info)
-
-        # Create the actual download object.
-        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-        stream = io.BytesIO()
-        download = resumable_requests.Download(media_url, stream=stream)
-        # Consume the resource.
-        response = download.consume(authorized_transport)
-        assert response.status_code == http_client.OK
-        with pytest.raises(RuntimeError) as exc_info:
-            getattr(response, u"content")
-        assert exc_info.value.args == (NO_BODY_ERR,)
-        assert response._content is False
-        assert response._content_consumed is True
-        assert stream.getvalue() == actual_contents
-        check_tombstoned(download, authorized_transport)
-
-
-@pytest.mark.xfail  # See: #76
-def test_corrupt_download(add_files, corrupting_transport):
-    for info in ALL_FILES:
-        blob_name = get_blob_name(info)
-
-        # Create the actual download object.
-        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-        stream = io.BytesIO()
-        download = resumable_requests.Download(media_url, stream=stream)
-        # Consume the resource.
-        with pytest.raises(common.DataCorruption) as exc_info:
-            download.consume(corrupting_transport)
-
-        assert download.finished
-        msg = download_mod._CHECKSUM_MISMATCH.format(
-            download.media_url,
-            CorruptingAuthorizedSession.EMPTY_HASH,
-            info[u"checksum"],
-        )
-        assert exc_info.value.args == (msg,)
-
-
-def test_extra_headers(authorized_transport, secret_file):
-    blob_name, data, headers = secret_file
-    # Create the actual download object.
-    media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-    download = resumable_requests.Download(media_url, headers=headers)
-    # Consume the resource.
-    response = download.consume(authorized_transport)
-    assert response.status_code == http_client.OK
-    assert response.content == data
-    check_tombstoned(download, authorized_transport)
-    # Attempt to consume the resource **without** the headers.
-    download_wo = resumable_requests.Download(media_url)
-    with pytest.raises(common.InvalidResponse) as exc_info:
-        download_wo.consume(authorized_transport)
-
-    check_error_response(exc_info, http_client.BAD_REQUEST, ENCRYPTED_ERR)
-    check_tombstoned(download_wo, authorized_transport)
-
-
-def test_non_existent_file(authorized_transport, bucket):
-    blob_name = u"does-not-exist.txt"
-    media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-    download = resumable_requests.Download(media_url)
-
-    # Try to consume the resource and fail.
-    with pytest.raises(common.InvalidResponse) as exc_info:
-        download.consume(authorized_transport)
-    check_error_response(exc_info, http_client.NOT_FOUND, NOT_FOUND_ERR)
-    check_tombstoned(download, authorized_transport)
-
-
-def test_bad_range(simple_file, authorized_transport):
-    blob_name, data = simple_file
-    # Make sure we have an invalid range.
-    start = 32
-    end = 63
-    assert len(data) < start < end
-    # Create the actual download object.
-    media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-    download = resumable_requests.Download(media_url, start=start, end=end)
-
-    # Try to consume the resource and fail.
-    with pytest.raises(common.InvalidResponse) as exc_info:
-        download.consume(authorized_transport)
-
-    check_error_response(
-        exc_info,
-        http_client.REQUESTED_RANGE_NOT_SATISFIABLE,
-        b"Request range not satisfiable",
-    )
-    check_tombstoned(download, authorized_transport)
-
-
-def _download_slice(media_url, slice_):
-    assert slice_.step is None
-
-    end = None
-    if slice_.stop is not None:
-        end = slice_.stop - 1
-
-    return resumable_requests.Download(media_url, start=slice_.start, end=end)
-
-
-def test_download_partial(add_files, authorized_transport):
-    for info in ALL_FILES:
-        actual_contents = get_contents(info)
-        blob_name = get_blob_name(info)
-
-        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-        for slice_ in info[u"slices"]:
-            download = _download_slice(media_url, slice_)
+            # Create the actual download object.
+            media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+            download = self._make_one(media_url)
+            # Consume the resource.
             response = download.consume(authorized_transport)
-            assert response.status_code == http_client.PARTIAL_CONTENT
-            assert response.content == actual_contents[slice_]
-            with pytest.raises(ValueError):
-                download.consume(authorized_transport)
+            assert response.status_code == http_client.OK
+            assert response.content == actual_contents
+            check_tombstoned(download, authorized_transport)
+
+    def test_download_to_stream(self, add_files, authorized_transport):
+        for info in ALL_FILES:
+            actual_contents = get_contents(info)
+            blob_name = get_blob_name(info)
+
+            # Create the actual download object.
+            media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+            stream = io.BytesIO()
+            download = self._make_one(media_url, stream=stream)
+            # Consume the resource.
+            response = download.consume(authorized_transport)
+            assert response.status_code == http_client.OK
+            with pytest.raises(RuntimeError) as exc_info:
+                getattr(response, u"content")
+            assert exc_info.value.args == (NO_BODY_ERR,)
+            assert response._content is False
+            assert response._content_consumed is True
+            assert stream.getvalue() == actual_contents
+            check_tombstoned(download, authorized_transport)
+
+    @pytest.mark.xfail  # See: #76
+    def test_corrupt_download(self, add_files, corrupting_transport):
+        for info in ALL_FILES:
+            blob_name = get_blob_name(info)
+
+            # Create the actual download object.
+            media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+            stream = io.BytesIO()
+            download = self._make_one(media_url, stream=stream)
+            # Consume the resource.
+            with pytest.raises(common.DataCorruption) as exc_info:
+                download.consume(corrupting_transport)
+
+            assert download.finished
+            msg = download_mod._CHECKSUM_MISMATCH.format(
+                download.media_url,
+                CorruptingAuthorizedSession.EMPTY_HASH,
+                info[u"checksum"],
+            )
+            assert exc_info.value.args == (msg,)
+
+    def test_extra_headers(self, authorized_transport, secret_file):
+        blob_name, data, headers = secret_file
+        # Create the actual download object.
+        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+        download = self._make_one(media_url, headers=headers)
+        # Consume the resource.
+        response = download.consume(authorized_transport)
+        assert response.status_code == http_client.OK
+        assert response.content == data
+        check_tombstoned(download, authorized_transport)
+        # Attempt to consume the resource **without** the headers.
+        download_wo = self._make_one(media_url)
+        with pytest.raises(common.InvalidResponse) as exc_info:
+            download_wo.consume(authorized_transport)
+
+        check_error_response(exc_info, http_client.BAD_REQUEST, ENCRYPTED_ERR)
+        check_tombstoned(download_wo, authorized_transport)
+
+    def test_non_existent_file(self, authorized_transport, bucket):
+        blob_name = u"does-not-exist.txt"
+        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+        download = self._make_one(media_url)
+
+        # Try to consume the resource and fail.
+        with pytest.raises(common.InvalidResponse) as exc_info:
+            download.consume(authorized_transport)
+        check_error_response(exc_info, http_client.NOT_FOUND, NOT_FOUND_ERR)
+        check_tombstoned(download, authorized_transport)
+
+    def test_bad_range(self, simple_file, authorized_transport):
+        blob_name, data = simple_file
+        # Make sure we have an invalid range.
+        start = 32
+        end = 63
+        assert len(data) < start < end
+        # Create the actual download object.
+        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+        download = self._make_one(media_url, start=start, end=end)
+
+        # Try to consume the resource and fail.
+        with pytest.raises(common.InvalidResponse) as exc_info:
+            download.consume(authorized_transport)
+
+        check_error_response(
+            exc_info,
+            http_client.REQUESTED_RANGE_NOT_SATISFIABLE,
+            b"Request range not satisfiable",
+        )
+        check_tombstoned(download, authorized_transport)
+
+    def _download_slice(self, media_url, slice_):
+        assert slice_.step is None
+
+        end = None
+        if slice_.stop is not None:
+            end = slice_.stop - 1
+
+        return self._make_one(media_url, start=slice_.start, end=end)
+
+    def test_download_partial(self, add_files, authorized_transport):
+        for info in ALL_FILES:
+            actual_contents = get_contents(info)
+            blob_name = get_blob_name(info)
+
+            media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+            for slice_ in info[u"slices"]:
+                download = self._download_slice(media_url, slice_)
+                response = download.consume(authorized_transport)
+                assert response.status_code == http_client.PARTIAL_CONTENT
+                assert response.content == actual_contents[slice_]
+                with pytest.raises(ValueError):
+                    download.consume(authorized_transport)
 
 
 def get_chunk_size(min_chunks, total_bytes):
@@ -392,105 +396,110 @@ def consume_chunks(download, authorized_transport, total_bytes, actual_contents)
     return num_responses, response
 
 
-@pytest.mark.xfail  # See issue #56
-def test_chunked_download(add_files, authorized_transport):
-    for info in ALL_FILES:
-        actual_contents = get_contents(info)
-        blob_name = get_blob_name(info)
+class TestChunkedDownload(object):
 
-        total_bytes = len(actual_contents)
-        num_chunks, chunk_size = get_chunk_size(7, total_bytes)
-        # Create the actual download object.
-        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-        stream = io.BytesIO()
-        download = resumable_requests.ChunkedDownload(media_url, chunk_size, stream)
-        # Consume the resource in chunks.
-        num_responses, last_response = consume_chunks(
-            download, authorized_transport, total_bytes, actual_contents
-        )
-        # Make sure the combined chunks are the whole object.
-        assert stream.getvalue() == actual_contents
-        # Check that we have the right number of responses.
-        assert num_responses == num_chunks
-        # Make sure the last chunk isn't the same size.
-        assert total_bytes % chunk_size != 0
-        assert len(last_response.content) < chunk_size
-        check_tombstoned(download, authorized_transport)
+    @staticmethod
+    def _get_target_class():
+        return resumable_requests.ChunkedDownload
 
+    def _make_one(self, media_url, chunk_size, stream, **kw):
+        return self._get_target_class()(media_url, chunk_size, stream, **kw)
 
-def test_chunked_download_partial(add_files, authorized_transport):
-    for info in ALL_FILES:
-        actual_contents = get_contents(info)
-        blob_name = get_blob_name(info)
+    @pytest.mark.xfail  # See issue #56
+    def test_chunked_download(self, add_files, authorized_transport):
+        for info in ALL_FILES:
+            actual_contents = get_contents(info)
+            blob_name = get_blob_name(info)
 
-        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-        for slice_ in info[u"slices"]:
-            # Manually replace a missing start with 0.
-            start = 0 if slice_.start is None else slice_.start
-            # Chunked downloads don't support a negative index.
-            if start < 0:
-                continue
-
-            # First determine how much content is in the slice and
-            # use it to determine a chunking strategy.
             total_bytes = len(actual_contents)
-            if slice_.stop is None:
-                end_byte = total_bytes - 1
-                end = None
-            else:
-                # Python slices DO NOT include the last index, though a byte
-                # range **is** inclusive of both endpoints.
-                end_byte = slice_.stop - 1
-                end = end_byte
-
-            num_chunks, chunk_size = get_chunk_size(7, end_byte - start + 1)
+            num_chunks, chunk_size = get_chunk_size(7, total_bytes)
             # Create the actual download object.
+            media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
             stream = io.BytesIO()
-            download = resumable_requests.ChunkedDownload(
-                media_url, chunk_size, stream, start=start, end=end
-            )
+            download = self._make_one(media_url, chunk_size, stream)
             # Consume the resource in chunks.
             num_responses, last_response = consume_chunks(
                 download, authorized_transport, total_bytes, actual_contents
             )
-
-            # Make sure the combined chunks are the whole slice.
-            assert stream.getvalue() == actual_contents[slice_]
+            # Make sure the combined chunks are the whole object.
+            assert stream.getvalue() == actual_contents
             # Check that we have the right number of responses.
             assert num_responses == num_chunks
             # Make sure the last chunk isn't the same size.
+            assert total_bytes % chunk_size != 0
             assert len(last_response.content) < chunk_size
             check_tombstoned(download, authorized_transport)
 
+    def test_chunked_download_partial(self, add_files, authorized_transport):
+        for info in ALL_FILES:
+            actual_contents = get_contents(info)
+            blob_name = get_blob_name(info)
 
-def test_chunked_with_extra_headers(authorized_transport, secret_file):
-    blob_name, data, headers = secret_file
-    num_chunks = 4
-    chunk_size = 12
-    assert (num_chunks - 1) * chunk_size < len(data) < num_chunks * chunk_size
-    # Create the actual download object.
-    media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
-    stream = io.BytesIO()
-    download = resumable_requests.ChunkedDownload(
-        media_url, chunk_size, stream, headers=headers
-    )
-    # Consume the resource in chunks.
-    num_responses, last_response = consume_chunks(
-        download, authorized_transport, len(data), data
-    )
-    # Make sure the combined chunks are the whole object.
-    assert stream.getvalue() == data
-    # Check that we have the right number of responses.
-    assert num_responses == num_chunks
-    # Make sure the last chunk isn't the same size.
-    assert len(last_response.content) < chunk_size
-    check_tombstoned(download, authorized_transport)
-    # Attempt to consume the resource **without** the headers.
-    stream_wo = io.BytesIO()
-    download_wo = resumable_requests.ChunkedDownload(media_url, chunk_size, stream_wo)
-    with pytest.raises(common.InvalidResponse) as exc_info:
-        download_wo.consume_next_chunk(authorized_transport)
+            media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+            for slice_ in info[u"slices"]:
+                # Manually replace a missing start with 0.
+                start = 0 if slice_.start is None else slice_.start
+                # Chunked downloads don't support a negative index.
+                if start < 0:
+                    continue
 
-    assert stream_wo.tell() == 0
-    check_error_response(exc_info, http_client.BAD_REQUEST, ENCRYPTED_ERR)
-    assert download_wo.invalid
+                # First determine how much content is in the slice and
+                # use it to determine a chunking strategy.
+                total_bytes = len(actual_contents)
+                if slice_.stop is None:
+                    end_byte = total_bytes - 1
+                    end = None
+                else:
+                    # Python slices DO NOT include the last index, though a byte
+                    # range **is** inclusive of both endpoints.
+                    end_byte = slice_.stop - 1
+                    end = end_byte
+
+                num_chunks, chunk_size = get_chunk_size(7, end_byte - start + 1)
+                # Create the actual download object.
+                stream = io.BytesIO()
+                download = self._make_one(
+                    media_url, chunk_size, stream, start=start, end=end
+                )
+                # Consume the resource in chunks.
+                num_responses, last_response = consume_chunks(
+                    download, authorized_transport, total_bytes, actual_contents
+                )
+
+                # Make sure the combined chunks are the whole slice.
+                assert stream.getvalue() == actual_contents[slice_]
+                # Check that we have the right number of responses.
+                assert num_responses == num_chunks
+                # Make sure the last chunk isn't the same size.
+                assert len(last_response.content) < chunk_size
+                check_tombstoned(download, authorized_transport)
+
+    def test_chunked_with_extra_headers(self, authorized_transport, secret_file):
+        blob_name, data, headers = secret_file
+        num_chunks = 4
+        chunk_size = 12
+        assert (num_chunks - 1) * chunk_size < len(data) < num_chunks * chunk_size
+        # Create the actual download object.
+        media_url = utils.DOWNLOAD_URL_TEMPLATE.format(blob_name=blob_name)
+        stream = io.BytesIO()
+        download = self._make_one(media_url, chunk_size, stream, headers=headers)
+        # Consume the resource in chunks.
+        num_responses, last_response = consume_chunks(
+            download, authorized_transport, len(data), data
+        )
+        # Make sure the combined chunks are the whole object.
+        assert stream.getvalue() == data
+        # Check that we have the right number of responses.
+        assert num_responses == num_chunks
+        # Make sure the last chunk isn't the same size.
+        assert len(last_response.content) < chunk_size
+        check_tombstoned(download, authorized_transport)
+        # Attempt to consume the resource **without** the headers.
+        stream_wo = io.BytesIO()
+        download_wo = resumable_requests.ChunkedDownload(media_url, chunk_size, stream_wo)
+        with pytest.raises(common.InvalidResponse) as exc_info:
+            download_wo.consume_next_chunk(authorized_transport)
+
+        assert stream_wo.tell() == 0
+        check_error_response(exc_info, http_client.BAD_REQUEST, ENCRYPTED_ERR)
+        assert download_wo.invalid

--- a/tests/system/requests/test_download.py
+++ b/tests/system/requests/test_download.py
@@ -73,6 +73,7 @@ class CorruptingAuthorizedSession(tr_requests.AuthorizedSession):
 def get_path(filename):
     return os.path.realpath(os.path.join(DATA_DIR, filename))
 
+
 ALL_FILES = (
     {
         u"path": get_path(u"image1.jpg"),
@@ -233,7 +234,6 @@ def check_error_response(exc_info, status_code, message):
 
 
 class TestDownload(object):
-
     @staticmethod
     def _get_target_class():
         return resumable_requests.Download
@@ -358,7 +358,6 @@ class TestDownload(object):
 
 
 class TestRawDownload(TestDownload):
-
     @staticmethod
     def _get_target_class():
         return resumable_requests.RawDownload
@@ -369,8 +368,9 @@ class TestRawDownload(TestDownload):
 
     @staticmethod
     def _read_response_content(response):
-        return b''.join(response.raw.stream(
-        _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False))
+        return b"".join(
+            response.raw.stream(_helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False)
+        )
 
     def test_corrupt_download(self, add_files, corrupting_transport):
         for info in ALL_FILES:
@@ -429,7 +429,6 @@ def consume_chunks(download, authorized_transport, total_bytes, actual_contents)
 
 
 class TestChunkedDownload(object):
-
     @staticmethod
     def _get_target_class():
         return resumable_requests.ChunkedDownload
@@ -507,7 +506,9 @@ class TestChunkedDownload(object):
         check_tombstoned(download, authorized_transport)
         # Attempt to consume the resource **without** the headers.
         stream_wo = io.BytesIO()
-        download_wo = resumable_requests.ChunkedDownload(media_url, chunk_size, stream_wo)
+        download_wo = resumable_requests.ChunkedDownload(
+            media_url, chunk_size, stream_wo
+        )
         with pytest.raises(common.InvalidResponse) as exc_info:
             download_wo.consume_next_chunk(authorized_transport)
 
@@ -517,7 +518,6 @@ class TestChunkedDownload(object):
 
 
 class TestRawChunkedDownload(TestChunkedDownload):
-
     @staticmethod
     def _get_target_class():
         return resumable_requests.RawChunkedDownload

--- a/tests/unit/requests/test__helpers.py
+++ b/tests/unit/requests/test__helpers.py
@@ -28,12 +28,12 @@ class TestRequestsMixin(object):
 
     def test__get_headers(self):
         headers = {u"fruit": u"apple"}
-        response = mock.Mock(headers=headers, spec=[u"headers"])
+        response = mock.Mock(headers=headers, spec=["headers"])
         assert headers == _helpers.RequestsMixin._get_headers(response)
 
     def test__get_body(self):
         body = b"This is the payload."
-        response = mock.Mock(content=body, spec=[u"content"])
+        response = mock.Mock(content=body, spec=["content"])
         assert body == _helpers.RequestsMixin._get_body(response)
 
 
@@ -80,11 +80,11 @@ def test_http_request_defaults():
 
 
 def _make_response(status_code):
-    return mock.Mock(status_code=status_code, spec=[u"status_code"])
+    return mock.Mock(status_code=status_code, spec=["status_code"])
 
 
 def _make_transport(*status_codes):
-    transport = mock.Mock(spec=[u"request"])
+    transport = mock.Mock(spec=["request"])
     responses = [_make_response(status_code) for status_code in status_codes]
     transport.request.side_effect = responses
     return transport, responses

--- a/tests/unit/requests/test__helpers.py
+++ b/tests/unit/requests/test__helpers.py
@@ -37,6 +37,23 @@ class TestRequestsMixin(object):
         assert body == _helpers.RequestsMixin._get_body(response)
 
 
+class TestRawRequestsMixin(object):
+    def test__get_body_wo_content_consumed(self):
+        body = b"This is the payload."
+        raw = mock.Mock(spec=["stream"])
+        raw.stream.return_value = iter([body])
+        response = mock.Mock(raw=raw, _content=False, spec=["raw", "_content"])
+        assert body == _helpers.RawRequestsMixin._get_body(response)
+        raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+        )
+
+    def test__get_body_w_content_consumed(self):
+        body = b"This is the payload."
+        response = mock.Mock(_content=body, spec=["_content"])
+        assert body == _helpers.RawRequestsMixin._get_body(response)
+
+
 def test_http_request():
     transport, responses = _make_transport(http_client.OK)
     method = u"POST"

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -19,7 +19,8 @@ import pytest
 from six.moves import http_client
 
 from google.resumable_media import common
-import google.resumable_media.requests.download as download_mod
+from google.resumable_media.requests import download as download_mod
+from google.resumable_media.requests import _helpers
 
 
 EXAMPLE_URL = (
@@ -47,7 +48,7 @@ class TestDownload(object):
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
         response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
+            chunk_size=_helpers._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
         )
 
     def test__write_to_stream_with_hash_check_success(self):
@@ -70,7 +71,7 @@ class TestDownload(object):
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
         response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
+            chunk_size=_helpers._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
         )
 
     def test__write_to_stream_with_hash_check_fail(self):
@@ -103,7 +104,7 @@ class TestDownload(object):
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
         response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
+            chunk_size=_helpers._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
         )
 
     def _consume_helper(
@@ -150,7 +151,7 @@ class TestDownload(object):
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
         response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
+            chunk_size=_helpers._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
         )
 
     def test_consume_with_stream_hash_check_success(self):
@@ -169,7 +170,7 @@ class TestDownload(object):
         response.__enter__.assert_called_once_with()
         response.__exit__.assert_called_once_with(None, None, None)
         response.iter_content.assert_called_once_with(
-            chunk_size=download_mod._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
+            chunk_size=_helpers._SINGLE_GET_CHUNK_SIZE, decode_unicode=False
         )
 
     def test_consume_with_stream_hash_check_fail(self):
@@ -182,6 +183,201 @@ class TestDownload(object):
         headers = {download_mod._HASH_HEADER: header_value}
         transport = mock.Mock(spec=["request"])
         transport.request.return_value = _mock_response(chunks=chunks, headers=headers)
+
+        assert not download.finished
+        with pytest.raises(common.DataCorruption) as exc_info:
+            download.consume(transport)
+
+        assert stream.getvalue() == b"".join(chunks)
+        assert download.finished
+        assert download._headers == {}
+
+        error = exc_info.value
+        assert error.response is transport.request.return_value
+        assert len(error.args) == 1
+        good_checksum = u"1A/dxEpys717C6FH7FIWDw=="
+        msg = download_mod._CHECKSUM_MISMATCH.format(
+            EXAMPLE_URL, bad_checksum, good_checksum
+        )
+        assert error.args[0] == msg
+
+        # Check mocks.
+        transport.request.assert_called_once_with(
+            u"GET",
+            EXAMPLE_URL,
+            data=None,
+            headers={},
+            stream=True,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
+    def test_consume_with_headers(self):
+        headers = {}  # Empty headers
+        end = 16383
+        self._consume_helper(end=end, headers=headers)
+        range_bytes = u"bytes={:d}-{:d}".format(0, end)
+        # Make sure the headers have been modified.
+        assert headers == {u"range": range_bytes}
+
+
+class TestRawDownload(object):
+    def test__write_to_stream_no_hash_check(self):
+        stream = io.BytesIO()
+        download = download_mod.RawDownload(EXAMPLE_URL, stream=stream)
+
+        chunk1 = b"right now, "
+        chunk2 = b"but a little later"
+        response = _mock_raw_response(chunks=[chunk1, chunk2], headers={})
+
+        ret_val = download._write_to_stream(response)
+        assert ret_val is None
+
+        assert stream.getvalue() == chunk1 + chunk2
+
+        # Check mocks.
+        response.__enter__.assert_called_once_with()
+        response.__exit__.assert_called_once_with(None, None, None)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+        )
+
+    def test__write_to_stream_with_hash_check_success(self):
+        stream = io.BytesIO()
+        download = download_mod.RawDownload(EXAMPLE_URL, stream=stream)
+
+        chunk1 = b"first chunk, count starting at 0. "
+        chunk2 = b"second chunk, or chunk 1, which is better? "
+        chunk3 = b"ordinals and numerals and stuff."
+        header_value = u"crc32c=qmNCyg==,md5=fPAJHnnoi/+NadyNxT2c2w=="
+        headers = {download_mod._HASH_HEADER: header_value}
+        response = _mock_raw_response(chunks=[chunk1, chunk2, chunk3], headers=headers)
+
+        ret_val = download._write_to_stream(response)
+        assert ret_val is None
+
+        assert stream.getvalue() == chunk1 + chunk2 + chunk3
+
+        # Check mocks.
+        response.__enter__.assert_called_once_with()
+        response.__exit__.assert_called_once_with(None, None, None)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+        )
+
+    def test__write_to_stream_with_hash_check_fail(self):
+        stream = io.BytesIO()
+        download = download_mod.RawDownload(EXAMPLE_URL, stream=stream)
+
+        chunk1 = b"first chunk, count starting at 0. "
+        chunk2 = b"second chunk, or chunk 1, which is better? "
+        chunk3 = b"ordinals and numerals and stuff."
+        bad_checksum = u"d3JvbmcgbiBtYWRlIHVwIQ=="
+        header_value = u"crc32c=V0FUPw==,md5={}".format(bad_checksum)
+        headers = {download_mod._HASH_HEADER: header_value}
+        response = _mock_raw_response(chunks=[chunk1, chunk2, chunk3], headers=headers)
+
+        with pytest.raises(common.DataCorruption) as exc_info:
+            download._write_to_stream(response)
+
+        assert not download.finished
+
+        error = exc_info.value
+        assert error.response is response
+        assert len(error.args) == 1
+        good_checksum = u"fPAJHnnoi/+NadyNxT2c2w=="
+        msg = download_mod._CHECKSUM_MISMATCH.format(
+            EXAMPLE_URL, bad_checksum, good_checksum
+        )
+        assert error.args[0] == msg
+
+        # Check mocks.
+        response.__enter__.assert_called_once_with()
+        response.__exit__.assert_called_once_with(None, None, None)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+        )
+
+    def _consume_helper(
+        self, stream=None, end=65536, headers=None, chunks=(), response_headers=None
+    ):
+        download = download_mod.RawDownload(
+            EXAMPLE_URL, stream=stream, end=end, headers=headers
+        )
+        transport = mock.Mock(spec=["request"])
+        transport.request.return_value = _mock_raw_response(
+            chunks=chunks, headers=response_headers
+        )
+
+        assert not download.finished
+        ret_val = download.consume(transport)
+        assert ret_val is transport.request.return_value
+
+        if chunks:
+            assert stream is not None
+        transport.request.assert_called_once_with(
+            u"GET",
+            EXAMPLE_URL,
+            data=None,
+            headers=download._headers,
+            stream=True,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
+        range_bytes = u"bytes={:d}-{:d}".format(0, end)
+        assert download._headers[u"range"] == range_bytes
+        assert download.finished
+
+        return transport
+
+    def test_consume(self):
+        self._consume_helper()
+
+    def test_consume_with_stream(self):
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+        transport = self._consume_helper(stream=stream, chunks=chunks)
+
+        assert stream.getvalue() == b"".join(chunks)
+
+        # Check mocks.
+        response = transport.request.return_value
+        response.__enter__.assert_called_once_with()
+        response.__exit__.assert_called_once_with(None, None, None)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+        )
+
+    def test_consume_with_stream_hash_check_success(self):
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+        header_value = u"md5=JvS1wjMvfbCXgEGeaJJLDQ=="
+        headers = {download_mod._HASH_HEADER: header_value}
+        transport = self._consume_helper(
+            stream=stream, chunks=chunks, response_headers=headers
+        )
+
+        assert stream.getvalue() == b"".join(chunks)
+
+        # Check mocks.
+        response = transport.request.return_value
+        response.__enter__.assert_called_once_with()
+        response.__exit__.assert_called_once_with(None, None, None)
+        response.raw.stream.assert_called_once_with(
+            _helpers._SINGLE_GET_CHUNK_SIZE, decode_content=False
+        )
+
+    def test_consume_with_stream_hash_check_fail(self):
+        stream = io.BytesIO()
+        download = download_mod.RawDownload(EXAMPLE_URL, stream=stream)
+
+        chunks = (b"zero zero", b"niner tango")
+        bad_checksum = u"anVzdCBub3QgdGhpcyAxLA=="
+        header_value = u"crc32c=V0FUPw==,md5={}".format(bad_checksum)
+        headers = {download_mod._HASH_HEADER: header_value}
+        transport = mock.Mock(spec=["request"])
+        transport.request.return_value = _mock_raw_response(
+            chunks=chunks, headers=headers
+        )
 
         assert not download.finished
         with pytest.raises(common.DataCorruption) as exc_info:
@@ -445,3 +641,28 @@ def _mock_response(status_code=http_client.OK, chunks=(), headers=None):
             status_code=int(status_code),
             spec=["status_code", "headers"],
         )
+
+
+def _mock_raw_response(status_code=http_client.OK, chunks=(), headers=None):
+    if headers is None:
+        headers = {}
+
+    mock_raw = mock.Mock(headers=headers, spec=["stream"])
+    mock_raw.stream.return_value = iter(chunks)
+    response = mock.MagicMock(
+        headers=headers,
+        status_code=int(status_code),
+        raw=mock_raw,
+        spec=[
+            u"__enter__",
+            u"__exit__",
+            u"iter_content",
+            u"status_code",
+            u"headers",
+            u"raw",
+        ],
+    )
+    # i.e. context manager returns ``self``.
+    response.__enter__.return_value = response
+    response.__exit__.return_value = None
+    return response

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -137,7 +137,7 @@ class TestDownload(object):
         download = download_mod.Download(
             EXAMPLE_URL, stream=stream, end=end, headers=headers
         )
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         transport.request.return_value = _mock_response(
             chunks=chunks, headers=response_headers
         )
@@ -205,7 +205,7 @@ class TestDownload(object):
         bad_checksum = u"anVzdCBub3QgdGhpcyAxLA=="
         header_value = u"crc32c=V0FUPw==,md5={}".format(bad_checksum)
         headers = {download_mod._HASH_HEADER: header_value}
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         transport.request.return_value = _mock_response(chunks=chunks, headers=headers)
 
         assert not download.finished
@@ -265,7 +265,7 @@ class TestChunkedDownload(object):
             content=content,
             headers=response_headers,
             status_code=status_code,
-            spec=[u"content", u"headers", u"status_code"],
+            spec=["content", "headers", "status_code"],
         )
 
     def test_consume_next_chunk_already_finished(self):
@@ -275,7 +275,7 @@ class TestChunkedDownload(object):
             download.consume_next_chunk(None)
 
     def _mock_transport(self, start, chunk_size, total_bytes, content=b""):
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         assert len(content) == chunk_size
         transport.request.return_value = self._mock_response(
             start,
@@ -375,14 +375,14 @@ def test__DoNothingHash():
 
 class Test__add_decoder(object):
     def test_non_gzipped(self):
-        response_raw = mock.Mock(headers={}, spec=[u"headers"])
+        response_raw = mock.Mock(headers={}, spec=["headers"])
         md5_hash = download_mod._add_decoder(response_raw, mock.sentinel.md5_hash)
 
         assert md5_hash is mock.sentinel.md5_hash
 
     def test_gzipped(self):
         headers = {u"content-encoding": u"gzip"}
-        response_raw = mock.Mock(headers=headers, spec=[u"headers", u"_decoder"])
+        response_raw = mock.Mock(headers=headers, spec=["headers", "_decoder"])
         md5_hash = download_mod._add_decoder(response_raw, mock.sentinel.md5_hash)
 
         assert md5_hash is not mock.sentinel.md5_hash
@@ -412,7 +412,7 @@ def _mock_response(status_code=http_client.OK, chunks=(), headers=None):
         headers = {}
 
     if chunks:
-        mock_raw = mock.Mock(headers=headers, spec=[u"headers"])
+        mock_raw = mock.Mock(headers=headers, spec=["headers"])
         response = mock.MagicMock(
             headers=headers,
             status_code=int(status_code),
@@ -435,5 +435,5 @@ def _mock_response(status_code=http_client.OK, chunks=(), headers=None):
         return mock.Mock(
             headers=headers,
             status_code=int(status_code),
-            spec=[u"status_code", u"headers"],
+            spec=["status_code", "headers"],
         )

--- a/tests/unit/requests/test_upload.py
+++ b/tests/unit/requests/test_upload.py
@@ -47,7 +47,7 @@ class TestSimpleUpload(object):
         content_type = BASIC_CONTENT
         upload = upload_mod.SimpleUpload(SIMPLE_URL)
 
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         transport.request.return_value = _make_response()
         assert not upload.finished
         ret_val = upload.transmit(transport, data, content_type)
@@ -71,7 +71,7 @@ class TestMultipartUpload(object):
         content_type = BASIC_CONTENT
         upload = upload_mod.MultipartUpload(MULTIPART_URL)
 
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         transport.request.return_value = _make_response()
         assert not upload.finished
         ret_val = upload.transmit(transport, data, metadata, content_type)
@@ -108,7 +108,7 @@ class TestResumableUpload(object):
         stream = io.BytesIO(data)
         metadata = {u"name": u"got-jokes.txt"}
 
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         location = (u"http://test.invalid?upload_id=AACODBBBxuw9u3AA",)
         response_headers = {u"location": location}
         post_response = _make_response(headers=response_headers)
@@ -155,7 +155,7 @@ class TestResumableUpload(object):
 
     @staticmethod
     def _chunk_mock(status_code, response_headers):
-        transport = mock.Mock(spec=[u"request"])
+        transport = mock.Mock(spec=["request"])
         put_response = _make_response(status_code=status_code, headers=response_headers)
         transport.request.return_value = put_response
 
@@ -199,7 +199,7 @@ class TestResumableUpload(object):
     def test_recover(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
         upload._invalid = True  # Make sure invalid.
-        upload._stream = mock.Mock(spec=[u"seek"])
+        upload._stream = mock.Mock(spec=["seek"])
         upload._resumable_url = u"http://test.invalid?upload_id=big-deal"
 
         end = 55555
@@ -225,5 +225,5 @@ class TestResumableUpload(object):
 def _make_response(status_code=http_client.OK, headers=None):
     headers = headers or {}
     return mock.Mock(
-        headers=headers, status_code=status_code, spec=[u"headers", u"status_code"]
+        headers=headers, status_code=status_code, spec=["headers", "status_code"]
     )

--- a/tests/unit/test__download.py
+++ b/tests/unit/test__download.py
@@ -128,7 +128,7 @@ class TestDownload(object):
 
         # Make sure **not finished** before.
         assert not download.finished
-        response = mock.Mock(status_code=int(http_client.OK), spec=[u"status_code"])
+        response = mock.Mock(status_code=int(http_client.OK), spec=["status_code"])
         ret_val = download._process_response(response)
         assert ret_val is None
         # Make sure **finished** after.
@@ -141,7 +141,7 @@ class TestDownload(object):
         # Make sure **not finished** before.
         assert not download.finished
         response = mock.Mock(
-            status_code=int(http_client.NOT_FOUND), spec=[u"status_code"]
+            status_code=int(http_client.NOT_FOUND), spec=["status_code"]
         )
         with pytest.raises(common.InvalidResponse) as exc_info:
             download._process_response(response)
@@ -263,7 +263,7 @@ class TestChunkedDownload(object):
             content=content,
             headers=response_headers,
             status_code=status_code,
-            spec=[u"content", u"headers", u"status_code"],
+            spec=["content", "headers", "status_code"],
         )
 
     def test__prepare_request_already_finished(self):
@@ -353,7 +353,7 @@ class TestChunkedDownload(object):
 
     def test__process_response_bad_status(self):
         chunk_size = 384
-        stream = mock.Mock(spec=[u"write"])
+        stream = mock.Mock(spec=["write"])
         download = _download.ChunkedDownload(EXAMPLE_URL, chunk_size, stream)
         _fix_up_virtual(download)
 
@@ -396,7 +396,7 @@ class TestChunkedDownload(object):
         response = mock.Mock(
             headers={},
             status_code=int(http_client.PARTIAL_CONTENT),
-            spec=[u"headers", u"status_code"],
+            spec=["headers", "status_code"],
         )
         with pytest.raises(common.InvalidResponse) as exc_info:
             download._process_response(response)
@@ -430,7 +430,7 @@ class TestChunkedDownload(object):
             content=data,
             headers=headers,
             status_code=int(http_client.PARTIAL_CONTENT),
-            spec=[u"content", u"headers", u"status_code"],
+            spec=["content", "headers", "status_code"],
         )
         with pytest.raises(common.InvalidResponse) as exc_info:
             download._process_response(response)
@@ -447,7 +447,7 @@ class TestChunkedDownload(object):
 
     def test__process_response_body_wrong_length(self):
         chunk_size = 10
-        stream = mock.Mock(spec=[u"write"])
+        stream = mock.Mock(spec=["write"])
         download = _download.ChunkedDownload(EXAMPLE_URL, chunk_size, stream)
         _fix_up_virtual(download)
 
@@ -544,7 +544,7 @@ class TestChunkedDownload(object):
 
     def test__process_response_when_content_range_is_zero(self):
         chunk_size = 10
-        stream = mock.Mock(spec=[u"write"])
+        stream = mock.Mock(spec=["write"])
         download = _download.ChunkedDownload(EXAMPLE_URL, chunk_size, stream)
         _fix_up_virtual(download)
 
@@ -552,7 +552,7 @@ class TestChunkedDownload(object):
         headers = {u"content-range": content_range}
         status_code = http_client.REQUESTED_RANGE_NOT_SATISFIABLE
         response = mock.Mock(
-            headers=headers, status_code=status_code, spec=[u"headers", "status_code"]
+            headers=headers, status_code=status_code, spec=["headers", "status_code"]
         )
         download._process_response(response)
         stream.write.assert_not_called()
@@ -604,7 +604,7 @@ class Test_get_range_info(object):
     @staticmethod
     def _make_response(content_range):
         headers = {u"content-range": content_range}
-        return mock.Mock(headers=headers, spec=[u"headers"])
+        return mock.Mock(headers=headers, spec=["headers"])
 
     def _success_helper(self, **kwargs):
         content_range = u"Bytes 7-11/42"
@@ -644,7 +644,7 @@ class Test_get_range_info(object):
         callback.assert_called_once_with()
 
     def _missing_header_helper(self, **kwargs):
-        response = mock.Mock(headers={}, spec=[u"headers"])
+        response = mock.Mock(headers={}, spec=["headers"])
         with pytest.raises(common.InvalidResponse) as exc_info:
             _download.get_range_info(response, _get_headers, **kwargs)
 
@@ -667,7 +667,7 @@ class Test__check_for_zero_content_range(object):
     def _make_response(content_range, status_code):
         headers = {u"content-range": content_range}
         return mock.Mock(
-            headers=headers, status_code=status_code, spec=[u"headers", "status_code"]
+            headers=headers, status_code=status_code, spec=["headers", "status_code"]
         )
 
     def test_status_code_416_and_test_content_range_zero_both(self):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -30,7 +30,7 @@ class Test_header_required(object):
         name = u"some-header"
         value = u"The Right Hand Side"
         headers = {name: value, u"other-name": u"other-value"}
-        response = mock.Mock(headers=headers, spec=[u"headers"])
+        response = mock.Mock(headers=headers, spec=["headers"])
         result = _helpers.header_required(response, name, _get_headers, **kwargs)
         assert result == value
 
@@ -43,7 +43,7 @@ class Test_header_required(object):
         callback.assert_not_called()
 
     def _failure_helper(self, **kwargs):
-        response = mock.Mock(headers={}, spec=[u"headers"])
+        response = mock.Mock(headers={}, spec=["headers"])
         name = u"any-name"
         with pytest.raises(common.InvalidResponse) as exc_info:
             _helpers.header_required(response, name, _get_headers, **kwargs)
@@ -232,7 +232,7 @@ class Test_wait_and_retry(object):
 
 
 def _make_response(status_code):
-    return mock.Mock(status_code=status_code, spec=[u"status_code"])
+    return mock.Mock(status_code=status_code, spec=["status_code"])
 
 
 def _get_status_code(response):

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -577,7 +577,7 @@ class TestResumableUpload(object):
         response = mock.Mock(
             content=response_body,
             status_code=http_client.OK,
-            spec=[u"content", u"status_code"],
+            spec=["content", "status_code"],
         )
         ret_val = upload._process_response(response, bytes_sent)
         assert ret_val is None
@@ -703,7 +703,7 @@ class TestResumableUpload(object):
         _fix_up_virtual(upload)
 
         upload._invalid = True
-        upload._stream = mock.Mock(spec=[u"seek"])
+        upload._stream = mock.Mock(spec=["seek"])
         upload._bytes_uploaded = mock.sentinel.not_zero
         assert upload.bytes_uploaded != 0
 
@@ -720,7 +720,7 @@ class TestResumableUpload(object):
         _fix_up_virtual(upload)
 
         upload._invalid = True
-        upload._stream = mock.Mock(spec=[u"seek"])
+        upload._stream = mock.Mock(spec=["seek"])
         upload._bytes_uploaded = mock.sentinel.not_zero
 
         headers = {u"range": u"bites=9-11"}
@@ -744,7 +744,7 @@ class TestResumableUpload(object):
         _fix_up_virtual(upload)
 
         upload._invalid = True
-        upload._stream = mock.Mock(spec=[u"seek"])
+        upload._stream = mock.Mock(spec=["seek"])
         upload._bytes_uploaded = mock.sentinel.not_zero
         assert upload.bytes_uploaded != 0
 
@@ -925,7 +925,7 @@ class Test_get_content_range(object):
 def _make_response(status_code=http_client.OK, headers=None):
     headers = headers or {}
     return mock.Mock(
-        headers=headers, status_code=status_code, spec=[u"headers", u"status_code"]
+        headers=headers, status_code=status_code, spec=["headers", "status_code"]
     )
 
 


### PR DESCRIPTION
Restores "raw download" behavior as separate `RawDownload` and `RawChunkedDownload` classes:  the existing `Download` and `ChunkedDownload` classes retain their bad-but-backward-compatible behavior of expanding resources with `Content-Encoding` headers set.

Closes #106.