### PR TITLE
docs: corrects repo url in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     long_description=README,
     namespace_packages=['google'],
     scripts=[],
-    url='https://github.com/GoogleCloudPlatform/google-resumable-media-python',
+    url='https://github.com/googleapis/google-resumable-media-python',
     packages=setuptools.find_packages(exclude=('tests*',)),
     license='Apache 2.0',
     platforms='Posix; MacOS X; Windows',


### PR DESCRIPTION
Internal tools depend on reconciling the PyPI package metadata with the .repo-metadata.json in the repository. This PR corrects the URL in setup.py