### PR TITLE
chore: update client_documentation link

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "google-resumable-media",
     "name_pretty": "Google Resumable Media",
-    "client_documentation": "http://googleapis.dev/python/google-resumable-media/latest/",
+    "client_documentation": "https://googleapis.github.io/google-resumable-media-python/latest/",
     "release_level": "alpha",
     "language": "python",
     "repo": "googleapis/google-resumable-media-python",


### PR DESCRIPTION
Is this right? I was having trouble finding the docs on googleapis.dev, wondering if this got missed in the transition?