### PR TITLE
fix: accept `201 Created` as valid upload response

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -501,7 +501,7 @@ class ResumableUpload(UploadBase):
         """
         _helpers.require_status_code(
             response,
-            (http_client.OK,),
+            (http_client.OK, http_client.CREATED),
             self._get_status_code,
             callback=self._make_invalid,
         )

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -507,9 +507,10 @@ class TestResumableUpload(object):
 
         error = exc_info.value
         assert error.response is response
-        assert len(error.args) == 4
+        assert len(error.args) == 5
         assert error.args[1] == 403
         assert error.args[3] == 200
+        assert error.args[4] == 201
 
     def test__process_initiate_response(self):
         upload = _upload.ResumableUpload(RESUMABLE_URL, ONE_MB)


### PR DESCRIPTION
Supersedes: #125

Fixes: #124