### PR TITLE
chore(deps): pin 'google-crc32c < 0.2dev'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 REQUIREMENTS = [
     'six',
-    'google-crc32c >= 0.1.0; python_version>="3.5"',
+    'google-crc32c >= 0.1.0, < 0.2dev; python_version>="3.5"',
     'crcmod >= 1.7; python_version=="2.7"',
 ]
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
/cc @tswast

Prepare for upcoming version, which will namespace the module to avoid
conflict with the ICRAR version.

See: https://github.com/googleapis/python-crc32c/issues/29