### PR TITLE
feat: bump 'google-crc32c >= 1.0'

### DIFF
--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -187,9 +187,9 @@ def _get_crc32c_object():
     to use CRCMod. CRCMod might be using a 'slow' varietal. If so, warn...
     """
     try:
-        import crc32c
+        import google_crc32c
 
-        crc_obj = crc32c.Checksum()
+        crc_obj = google_crc32c.Checksum()
     except ImportError:
         try:
             import crcmod

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 REQUIREMENTS = [
     'six',
-    'google-crc32c >= 0.1.0, < 0.2dev; python_version>="3.5"',
+    'google-crc32c >= 1.0, < 2.0dev; python_version>="3.5"',
     'crcmod >= 1.7; python_version=="2.7"',
 ]
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
Uses the new namespaced-version of the library.

Release-As: 1.0.0