### PR TITLE
chore(deps): use google-auth >= 1.22.0, 2.0dev which includes google.auth.default_async, aiohttp_requests

### DIFF
--- a/google/async_resumable_media/requests/_request_helpers.py
+++ b/google/async_resumable_media/requests/_request_helpers.py
@@ -23,7 +23,7 @@ import functools
 from google.async_resumable_media import _helpers
 from google.resumable_media import common
 
-import google.auth.transport.aiohttp_requests as aiohttp_requests
+import google.auth.transport._aiohttp_requests as aiohttp_requests
 import aiohttp
 
 _DEFAULT_RETRY_STRATEGY = common.RetryStrategy()

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,8 +19,6 @@ import shutil
 import nox
 
 SYSTEM_TEST_ENV_VARS = ("GOOGLE_APPLICATION_CREDENTIALS",)
-GOOGLE_AUTH = "git+https://github.com/googleapis/google-auth-library-python.git@c9adc2744b37a41424e959bb11c3559c41e42496"
-# GOOGLE_AUTH = "google-auth >= 0.10.0"
 BLACK_VERSION = "black==20.8b1"
 
 DEFAULT_PYTHON_VERSION = "3.8"
@@ -36,7 +34,6 @@ def unit(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov", "pytest-asyncio")
     session.install("-e", ".[requests]")
-    session.install(GOOGLE_AUTH)
 
     # Run py.test against the unit tests.
     # NOTE: We don't require 100% line coverage for unit test runs since
@@ -65,7 +62,6 @@ def unit_2(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov")
     session.install("-e", ".[requests]")
-    session.install(GOOGLE_AUTH)
 
     # Run py.test against the unit tests.
     # NOTE: We don't require 100% line coverage for unit test runs since
@@ -149,7 +145,6 @@ def doctest(session):
         "sphinx_rtd_theme",
         "sphinx-docstring-typing >= 0.0.3",
         "mock",
-        GOOGLE_AUTH,
     )
 
     # Run the doctests with Sphinx.
@@ -228,7 +223,7 @@ def system(session):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install("mock", "pytest", GOOGLE_AUTH, "google-cloud-testutils")
+    session.install("mock", "pytest", "google-cloud-testutils")
     session.install("-e", ".[requests]")
 
     # Run py.test against the async system tests.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 REQUIREMENTS = [
     'six',
-    # 'google-auth >= 0.10.0',
+    'google-auth >= 1.22.0, < 2.0dev',
     'google-crc32c >= 1.0, < 2.0dev; python_version>="3.5"',
     'crcmod >= 1.7; python_version=="2.7"',
     'aiohttp >= 3.6.2, < 4.0.0dev; python_version>="3.6"'

--- a/tests_async/system/requests/conftest.py
+++ b/tests_async/system/requests/conftest.py
@@ -15,7 +15,6 @@
 
 from tests.system import utils
 
-import google.auth
 from google.auth._default_async import default_async
 import google.auth.transport._aiohttp_requests as tr_requests
 import pytest

--- a/tests_async/system/requests/conftest.py
+++ b/tests_async/system/requests/conftest.py
@@ -16,6 +16,7 @@
 from tests.system import utils
 
 import google.auth
+from google.auth._default_async import default_async
 import google.auth.transport._aiohttp_requests as tr_requests
 import pytest
 
@@ -43,13 +44,13 @@ async def cleanup_bucket(transport):
 
 
 def _get_authorized_transport():
-    credentials, project_id = google.auth._default_async(scopes=(utils.GCS_RW_SCOPE,))
+    credentials, project_id = default_async(scopes=(utils.GCS_RW_SCOPE,))
     return tr_requests.AuthorizedSession(credentials)
 
 
 @pytest.fixture(scope=u"module")
 async def authorized_transport():
-    credentials, project_id = google.auth._default_async(scopes=(utils.GCS_RW_SCOPE,))
+    credentials, project_id = default_async(scopes=(utils.GCS_RW_SCOPE,))
     yield _get_authorized_transport()
 
 

--- a/tests_async/system/requests/conftest.py
+++ b/tests_async/system/requests/conftest.py
@@ -16,7 +16,7 @@
 from tests.system import utils
 
 import google.auth
-import google.auth.transport.aiohttp_requests as tr_requests
+import google.auth.transport._aiohttp_requests as tr_requests
 import pytest
 
 
@@ -43,13 +43,13 @@ async def cleanup_bucket(transport):
 
 
 def _get_authorized_transport():
-    credentials, project_id = google.auth.default_async(scopes=(utils.GCS_RW_SCOPE,))
+    credentials, project_id = google.auth._default_async(scopes=(utils.GCS_RW_SCOPE,))
     return tr_requests.AuthorizedSession(credentials)
 
 
 @pytest.fixture(scope=u"module")
 async def authorized_transport():
-    credentials, project_id = google.auth.default_async(scopes=(utils.GCS_RW_SCOPE,))
+    credentials, project_id = google.auth._default_async(scopes=(utils.GCS_RW_SCOPE,))
     yield _get_authorized_transport()
 
 

--- a/tests_async/system/requests/test_download.py
+++ b/tests_async/system/requests/test_download.py
@@ -19,7 +19,7 @@ import io
 import os
 
 import google.auth
-import google.auth.transport.aiohttp_requests as tr_requests
+import google.auth.transport._aiohttp_requests as tr_requests
 import pytest
 from six.moves import http_client
 
@@ -185,7 +185,7 @@ async def secret_file(authorized_transport, bucket):
 # Transport that returns corrupt data, so we can exercise checksum handling.
 @pytest.fixture(scope=u"module")
 async def corrupting_transport():
-    credentials, _ = google.auth.default_async(scopes=(utils.GCS_RW_SCOPE,))
+    credentials, _ = google.auth._default_async(scopes=(utils.GCS_RW_SCOPE,))
     yield CorruptingAuthorizedSession(credentials)
 
 

--- a/tests_async/system/requests/test_download.py
+++ b/tests_async/system/requests/test_download.py
@@ -18,7 +18,6 @@ import hashlib
 import io
 import os
 
-import google.auth
 from google.auth._default_async import default_async
 import google.auth.transport._aiohttp_requests as tr_requests
 import pytest

--- a/tests_async/system/requests/test_download.py
+++ b/tests_async/system/requests/test_download.py
@@ -19,6 +19,7 @@ import io
 import os
 
 import google.auth
+from google.auth._default_async import default_async
 import google.auth.transport._aiohttp_requests as tr_requests
 import pytest
 from six.moves import http_client
@@ -185,7 +186,7 @@ async def secret_file(authorized_transport, bucket):
 # Transport that returns corrupt data, so we can exercise checksum handling.
 @pytest.fixture(scope=u"module")
 async def corrupting_transport():
-    credentials, _ = google.auth._default_async(scopes=(utils.GCS_RW_SCOPE,))
+    credentials, _ = default_async(scopes=(utils.GCS_RW_SCOPE,))
     yield CorruptingAuthorizedSession(credentials)
 
 

--- a/tests_async/unit/test__download.py
+++ b/tests_async/unit/test__download.py
@@ -22,7 +22,7 @@ from google.async_resumable_media import _download
 from google.resumable_media import common
 from tests.unit import test__download as sync_test
 
-import google.auth.transport.aiohttp_requests as aiohttp_requests
+import google.auth.transport._aiohttp_requests as aiohttp_requests
 
 EXAMPLE_URL = sync_test.EXAMPLE_URL
 


### PR DESCRIPTION
move google.auth.default_async, aiohttp_requests use to google.auth._default_async, _aiohttp_requests 