### PR TITLE
fix: add retries for 'requests.ConnectionError'

### DIFF
--- a/google/_async_resumable_media/_helpers.py
+++ b/google/_async_resumable_media/_helpers.py
@@ -19,9 +19,6 @@ import random
 import time
 
 
-from six.moves import http_client
-
-
 from google.resumable_media import common
 
 

--- a/google/_async_resumable_media/_helpers.py
+++ b/google/_async_resumable_media/_helpers.py
@@ -27,13 +27,6 @@ from google.resumable_media import common
 
 RANGE_HEADER = u"range"
 CONTENT_RANGE_HEADER = u"content-range"
-RETRYABLE = (  # ConnectionError is also retried, but is not listed here.
-    common.TOO_MANY_REQUESTS,  # 429
-    http_client.INTERNAL_SERVER_ERROR,  # 500
-    http_client.BAD_GATEWAY,  # 502
-    http_client.SERVICE_UNAVAILABLE,  # 503
-    http_client.GATEWAY_TIMEOUT,  # 504
-)
 
 _SLOW_CRC32C_WARNING = (
     "Currently using crcmod in pure python form. This is a slow "
@@ -173,7 +166,7 @@ async def wait_and_retry(func, get_status_code, retry_strategy):
         except ConnectionError as e:
             error = e
         else:
-            if get_status_code(response) not in RETRYABLE:
+            if get_status_code(response) not in common.RETRYABLE:
                 return response
 
         if not retry_strategy.retry_allowed(total_sleep, num_retries):

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -21,8 +21,6 @@ import random
 import time
 import warnings
 
-from six.moves import http_client
-
 from google.resumable_media import common
 
 

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -28,7 +28,7 @@ from google.resumable_media import common
 
 RANGE_HEADER = u"range"
 CONTENT_RANGE_HEADER = u"content-range"
-RETRYABLE = (  # ConnectionError is also retried, but is not listed here.
+RETRYABLE = (  # requests.ConnectionError is also retried, but is not listed here.
     common.TOO_MANY_REQUESTS,  # 429
     http_client.INTERNAL_SERVER_ERROR,  # 500
     http_client.BAD_GATEWAY,  # 502
@@ -171,6 +171,7 @@ def wait_and_retry(func, get_status_code, retry_strategy):
     # but due to loose coupling with the transport layer we can't guarantee it.
     try:
         import requests
+
         retriable_exception_type = requests.exceptions.ConnectionError
     except ImportError:
         retriable_exception_type = None

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -163,11 +163,11 @@ def wait_and_retry(func, get_status_code, retry_strategy):
     # present here and the transport to be using requests.exceptions errors,
     # but due to loose coupling with the transport layer we can't guarantee it.
     try:
-        import requests.exceptions
-
-        connection_error_exception = requests.exceptions.ConnectionError
+        connection_error_exception = _get_connection_error_class()
     except ImportError:
-        connection_error_exception = None
+        # We don't know the correct class to use to catch ConnectionError, so
+        # an empty tuple here communicates "catch no exception".
+        connection_error_exception = ()
 
     while True:  # return on success or when retries exhausted.
         error = None
@@ -360,6 +360,16 @@ def _get_checksum_object(checksum_type):
         return None
     else:
         raise ValueError("checksum must be ``'md5'``, ``'crc32c'`` or ``None``")
+
+
+def _get_connection_error_class():
+    """Get the exception error class.
+
+    This is a separate function for testing purposes."""
+
+    import requests.exceptions
+
+    return requests.exceptions.ConnectionError
 
 
 class _DoNothingHash(object):

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -14,6 +14,8 @@
 
 """Shared utilities used by both downloads and uploads."""
 
+from __future__ import absolute_import
+
 import base64
 import hashlib
 import logging
@@ -161,9 +163,9 @@ def wait_and_retry(func, get_status_code, retry_strategy):
     # present here and the transport to be using requests.exceptions errors,
     # but due to loose coupling with the transport layer we can't guarantee it.
     try:
-        import requests
+        import requests.exceptions
 
-        connection_error_exception = requests.ConnectionError
+        connection_error_exception = requests.exceptions.ConnectionError
     except ImportError:
         connection_error_exception = None
 

--- a/google/resumable_media/common.py
+++ b/google/resumable_media/common.py
@@ -17,6 +17,7 @@
 Includes custom exception types, useful constants and shared helpers.
 """
 
+from six.moves import http_client
 
 _SLEEP_RETRY_ERROR_MSG = (
     u"At most one of `max_cumulative_retry` and `max_retries` " u"can be specified."
@@ -61,7 +62,7 @@ exceeds this limit, no more retries will occur.
 """
 
 RETRYABLE = (
-    common.TOO_MANY_REQUESTS,  # 429
+    TOO_MANY_REQUESTS,  # 429
     http_client.INTERNAL_SERVER_ERROR,  # 500
     http_client.BAD_GATEWAY,  # 502
     http_client.SERVICE_UNAVAILABLE,  # 503

--- a/google/resumable_media/common.py
+++ b/google/resumable_media/common.py
@@ -60,6 +60,19 @@ This is provided (10 minutes) as a default. When the cumulative sleep
 exceeds this limit, no more retries will occur.
 """
 
+RETRYABLE = (
+    common.TOO_MANY_REQUESTS,  # 429
+    http_client.INTERNAL_SERVER_ERROR,  # 500
+    http_client.BAD_GATEWAY,  # 502
+    http_client.SERVICE_UNAVAILABLE,  # 503
+    http_client.GATEWAY_TIMEOUT,  # 504
+)
+"""iterable: HTTP status codes that indicate a retryable error.
+
+Connection errors are also retried, but are not listed as they are
+exceptions, not status codes.
+"""
+
 
 class InvalidResponse(Exception):
     """Error class for responses which are not in the correct state.

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -227,6 +227,29 @@ class Test_wait_and_retry(object):
 
     @mock.patch(u"time.sleep")
     @mock.patch(u"random.randint")
+    def test_connection_import_error_failure(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [125, 625, 375]
+
+        response = _make_response(http_client.NOT_FOUND)
+        responses = [
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectionError,
+            response,
+        ]
+
+        with mock.patch(
+            "google.resumable_media._helpers._get_connection_error_class",
+            side_effect=ImportError,
+        ):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                func = mock.Mock(side_effect=responses, spec=[])
+
+                retry_strategy = common.RetryStrategy()
+                _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
+
+    @mock.patch(u"time.sleep")
+    @mock.patch(u"random.randint")
     def test_retry_exceeds_max_cumulative(self, randint_mock, sleep_mock):
         randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -239,7 +239,7 @@ class Test_wait_and_retry(object):
         ]
 
         with mock.patch(
-            "google.resumable_media._helpers._get_connection_error_class",
+            "google.resumable_media._helpers._get_connection_error_classes",
             side_effect=ImportError,
         ):
             with pytest.raises(requests.exceptions.ConnectionError):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -194,6 +194,32 @@ class Test_wait_and_retry(object):
 
     @mock.patch(u"time.sleep")
     @mock.patch(u"random.randint")
+    def test_success_with_retry_connection_error(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [125, 625, 375]
+
+        response = _make_response(http_client.NOT_FOUND)
+        import requests
+        responses = [requests.ConnectionError, requests.ConnectionError, requests.ConnectionError, response]
+        func = mock.Mock(side_effect=responses, spec=[])
+
+        retry_strategy = common.RetryStrategy()
+        ret_val = _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
+
+        assert ret_val == responses[-1]
+
+        assert func.call_count == 4
+        assert func.mock_calls == [mock.call()] * 4
+
+        assert randint_mock.call_count == 3
+        assert randint_mock.mock_calls == [mock.call(0, 1000)] * 3
+
+        assert sleep_mock.call_count == 3
+        sleep_mock.assert_any_call(1.125)
+        sleep_mock.assert_any_call(2.625)
+        sleep_mock.assert_any_call(4.375)
+
+    @mock.patch(u"time.sleep")
+    @mock.patch(u"random.randint")
     def test_retry_exceeds_max_cumulative(self, randint_mock, sleep_mock):
         randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import hashlib
 import mock
 import pytest
-import requests
+import requests.exceptions
 from six.moves import http_client
 
 from google.resumable_media import _helpers
@@ -200,9 +202,9 @@ class Test_wait_and_retry(object):
 
         response = _make_response(http_client.NOT_FOUND)
         responses = [
-            requests.ConnectionError,
-            requests.ConnectionError,
-            requests.ConnectionError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectionError,
             response,
         ]
         func = mock.Mock(side_effect=responses, spec=[])
@@ -267,11 +269,11 @@ class Test_wait_and_retry(object):
     def test_retry_exceeded_reraises_connection_error(self, randint_mock, sleep_mock):
         randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
 
-        responses = [requests.ConnectionError] * 8
+        responses = [requests.exceptions.ConnectionError] * 8
         func = mock.Mock(side_effect=responses, spec=[])
 
         retry_strategy = common.RetryStrategy(max_cumulative_retry=100.0)
-        with pytest.raises(requests.ConnectionError):
+        with pytest.raises(requests.exceptions.ConnectionError):
             _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
 
         assert func.call_count == 8

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -152,7 +152,7 @@ class Test_calculate_retry_wait(object):
 class Test_wait_and_retry(object):
     def test_success_no_retry(self):
         truthy = http_client.OK
-        assert truthy not in _helpers.RETRYABLE
+        assert truthy not in common.RETRYABLE
         response = _make_response(truthy)
 
         func = mock.Mock(return_value=response, spec=[])
@@ -180,7 +180,7 @@ class Test_wait_and_retry(object):
         ret_val = _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
 
         assert ret_val == responses[-1]
-        assert status_codes[-1] not in _helpers.RETRYABLE
+        assert status_codes[-1] not in common.RETRYABLE
 
         assert func.call_count == 4
         assert func.mock_calls == [mock.call()] * 4
@@ -245,7 +245,7 @@ class Test_wait_and_retry(object):
         ret_val = _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
 
         assert ret_val == responses[-1]
-        assert status_codes[-1] in _helpers.RETRYABLE
+        assert status_codes[-1] in common.RETRYABLE
 
         assert func.call_count == 8
         assert func.mock_calls == [mock.call()] * 8

--- a/tests_async/unit/test__helpers.py
+++ b/tests_async/unit/test__helpers.py
@@ -153,7 +153,7 @@ class Test_wait_and_retry(object):
     @pytest.mark.asyncio
     async def test_success_no_retry(self):
         truthy = http_client.OK
-        assert truthy not in _helpers.RETRYABLE
+        assert truthy not in common.RETRYABLE
         response = _make_response(truthy)
 
         func = mock.AsyncMock(return_value=response, spec=[])
@@ -182,7 +182,7 @@ class Test_wait_and_retry(object):
         ret_val = await _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
 
         assert ret_val == responses[-1]
-        assert status_codes[-1] not in _helpers.RETRYABLE
+        assert status_codes[-1] not in common.RETRYABLE
 
         assert func.call_count == 4
         assert func.mock_calls == [mock.call()] * 4


### PR DESCRIPTION
Restructures retry strategy to check both status codes and exceptions; then, adds requests.ConnectionError as a retriable exception. (Note: the unified standard library ConnectionError class is not used because it is unsupported by both Requests and Python 2).