### PR TITLE
chore: allow Sphinx 1.5.5 FBO docfx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.6.3"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
See [this Kokoro failure](https://source.cloud.google.com/results/invocations/6d54aa59-12fc-47f1-b426-e67519340941/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fgoogle-resumable-media-python%2Fpresubmit%2Fpresubmit/log).