### PR TITLE
fix: handle none string values in headers

### DIFF
--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -328,7 +328,7 @@ def _parse_checksum_header(header_value, response, checksum_label):
         ~google.resumable_media.common.InvalidResponse: If there are
             multiple checksums of the requested type in ``header_value``.
     """
-    if header_value is None:
+    if header_value == "None" or header_value is None:
         return None
 
     matches = []

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -501,6 +501,18 @@ class Test__parse_checksum_header(object):
         )
         assert crc32c_header is None
 
+    def test_none_str_value(self):
+        header_value = "None"
+        response = None
+        md5_header = _helpers._parse_checksum_header(
+            header_value, response, checksum_label="md5"
+        )
+        assert md5_header is None
+        crc32c_header = _helpers._parse_checksum_header(
+            header_value, response, checksum_label="crc32c"
+        )
+        assert crc32c_header is None
+
     def test_crc32c_only(self):
         header_value = u"crc32c={}".format(self.CRC32C_CHECKSUM)
         response = None


### PR DESCRIPTION
Handle string type "None" header values within [`_helpers._parse_checksum_header`](https://github.com/googleapis/google-resumable-media-python/blob/73080754bf435b49784c67a2363a7b0614222a22/google/resumable_media/_helpers.py#L301) 

Considering that an HTTP response object `headers` attribute is a `Mapping[str, str]`, checking for cases where the empty header value is parsed as `"None"` string type in addition to `None` type.

Fixes #233 