### PR TITLE
fix: add retry coverage to the streaming portion of a download

### DIFF
--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -210,15 +210,14 @@ class Download(DownloadBase):
         raise NotImplementedError(u"This implementation is virtual.")
 
     def _consume_with_retries(self, func, transport, timeout=None):
-        """Attempts to retry a call to ``func`` until success.
+        """Attempts to retry a download and consume until success.
 
-        Expects ``func`` to return an HTTP response and uses ``get_status_code``
-        to check if the response is retry-able.
+        The consume ``func`` is retry-able based on the HTTP response and
+        connection error type. Retry covers both the initial response and
+        the streaming portion of the download.
 
         Will retry until :meth:`~.RetryStrategy.retry_allowed` (on the current
-        ``retry_strategy``) returns :data:`False`. Uses
-        :func:`calculate_retry_wait` to double the wait time (with jitter) after
-        each attempt.
+        ``retry_strategy``) returns :data:`False`.
 
         Args:
             func (Callable): A callable that takes no arguments and produces
@@ -234,7 +233,7 @@ class Download(DownloadBase):
                 See :meth:`requests.Session.request` documentation for details.
 
         Returns:
-            ~requests.Response: The HTTP response returned by ``transport``.
+            ~requests.Response: The return value of ``transport.request()``.
         """
         func_to_retry = functools.partial(func, transport=transport, timeout=timeout)
         return _helpers.wait_and_retry(
@@ -473,15 +472,14 @@ class ChunkedDownload(DownloadBase):
         raise NotImplementedError(u"This implementation is virtual.")
 
     def _consume_with_retries(self, func, transport, timeout=None):
-        """Attempts to retry a call to ``func`` until success.
+        """Attempts to retry a consume_next_chunk until success.
 
-        Expects ``func`` to return an HTTP response and uses ``get_status_code``
-        to check if the response is retry-able.
+        The consume_next_chunk ``func`` is retry-able based on the HTTP response
+        and connection error type. Retry covers both the initial response and
+        the streaming portion of the download.
 
         Will retry until :meth:`~.RetryStrategy.retry_allowed` (on the current
-        ``retry_strategy``) returns :data:`False`. Uses
-        :func:`calculate_retry_wait` to double the wait time (with jitter) after
-        each attempt.
+        ``retry_strategy``) returns :data:`False`.
 
         Args:
             func (Callable): A callable that takes no arguments and produces
@@ -497,7 +495,7 @@ class ChunkedDownload(DownloadBase):
                 See :meth:`requests.Session.request` documentation for details.
 
         Returns:
-            ~requests.Response: The HTTP response returned by ``transport``.
+            ~requests.Response: The return value of ``transport.request()``.
         """
         func_to_retry = functools.partial(func, transport=transport, timeout=timeout)
         return _helpers.wait_and_retry(

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -127,10 +127,10 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the resource to be downloaded.
+        """Consume the resource to be downloaded without any retries.
 
-        If a ``stream`` is attached to this download, then the downloaded
-        resource will be written to the stream.
+        This is intended to be called by :meth:`consume` so it can be
+        wrapped with error handling and retry strategy.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -180,6 +180,9 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
         ),
     ):
         """Consume the resource to be downloaded.
+
+        If a ``stream`` is attached to this download, then the downloaded
+        resource will be written to the stream.
 
         This operation is retry-able based on the download HTTP response and
         connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
@@ -296,10 +299,10 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the resource to be downloaded.
+        """Consume the resource to be downloaded without any retries.
 
-        If a ``stream`` is attached to this download, then the downloaded
-        resource will be written to the stream.
+        This is intended to be called by :meth:`consume` so it can be
+        wrapped with error handling and retry strategy.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -348,6 +351,9 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
         ),
     ):
         """Consume the resource to be downloaded.
+
+        If a ``stream`` is attached to this download, then the downloaded
+        resource will be written to the stream.
 
         This operation is retry-able based on the download HTTP response and
         connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
@@ -414,7 +420,10 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the next chunk of the resource to be downloaded.
+        """Consume the next chunk of the resource to be downloaded without any retries.
+
+        This is intended to be called by :meth:`consume_next_chunk` so it can be
+        wrapped with error handling and retry strategy.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -453,6 +462,26 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
+        """Consume the next chunk of the resource to be downloaded.
+
+        This operation is retry-able based on the download HTTP response and
+        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
+        (on the current``self._retry_strategy``) returns :data:`False`.
+
+        Args:
+            transport (~requests.Session): A ``requests`` object which can
+                make authenticated requests.
+            timeout (Optional[Union[float, Tuple[float, float]]]):
+                The number of seconds to wait for the server response.
+                Depending on the retry strategy, a request may be repeated
+                several times using the same timeout each time.
+                Can also be passed as a tuple (connect_timeout, read_timeout).
+                See :meth:`requests.Session.request` documentation for details.
+        Returns:
+            ~requests.Response: The HTTP response returned by ``transport``.
+        Raises:
+            ValueError: If the current download has finished.
+        """
         return self._consume_with_retries(
             self._consume_next_chunk, transport=transport, timeout=timeout
         )
@@ -494,7 +523,10 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the next chunk of the resource to be downloaded.
+        """Consume the next chunk of the resource to be downloaded without any retries.
+
+        This is intended to be called by :meth:`consume_next_chunk` so it can be
+        wrapped with error handling and retry strategy.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -534,6 +566,26 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
+        """Consume the next chunk of the resource to be downloaded.
+
+        This operation is retry-able based on the download HTTP response and
+        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
+        (on the current``self._retry_strategy``) returns :data:`False`.
+
+        Args:
+            transport (~requests.Session): A ``requests`` object which can
+                make authenticated requests.
+            timeout (Optional[Union[float, Tuple[float, float]]]):
+                The number of seconds to wait for the server response.
+                Depending on the retry strategy, a request may be repeated
+                several times using the same timeout each time.
+                Can also be passed as a tuple (connect_timeout, read_timeout).
+                See :meth:`requests.Session.request` documentation for details.
+        Returns:
+            ~requests.Response: The HTTP response returned by ``transport``.
+        Raises:
+            ValueError: If the current download has finished.
+        """
         return self._consume_with_retries(
             self._consume_next_chunk, transport=transport, timeout=timeout
         )

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -14,6 +14,8 @@
 
 """Support for downloading media from Google APIs."""
 
+import functools
+import time
 import urllib3.response
 
 from google.resumable_media import _download
@@ -119,7 +121,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
                 )
                 raise common.DataCorruption(response, msg)
 
-    def consume(
+    def original_consume(
         self,
         transport,
         timeout=(
@@ -171,6 +173,74 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             self._write_to_stream(result)
 
         return result
+
+    def consume(
+        self,
+        transport,
+        timeout=(
+            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
+            _request_helpers._DEFAULT_READ_TIMEOUT,
+        ),
+    ):
+        total_sleep = 0.0
+        num_retries = 0
+        # base_wait will be multiplied by the multiplier on the first retry.
+        base_wait = (
+            float(self._retry_strategy.initial_delay) / self._retry_strategy.multiplier
+        )
+
+        method, url, payload, headers = self._prepare_request()
+        # NOTE: We assume "payload is None" but pass it along anyway.
+        request_kwargs = {
+            u"data": payload,
+            u"headers": headers,
+            u"timeout": timeout,
+        }
+        if self._stream is not None:
+            request_kwargs[u"stream"] = True
+
+        func = functools.partial(transport.request, method, url, **request_kwargs)
+
+        # Set the retriable_exception_type if possible. We expect requests to be
+        # present here and the transport to be using requests.exceptions errors,
+        # but due to loose coupling with the transport layer we can't guarantee it.
+        try:
+            connection_error_exceptions = _helpers._get_connection_error_classes()
+        except ImportError:
+            # We don't know the correct classes to use to catch connection errors,
+            # so an empty tuple here communicates "catch no exceptions".
+            connection_error_exceptions = ()
+
+        while True:  # return on success or when retries exhausted.
+            error = None
+            try:
+                response = func()
+                self._process_response(response)
+                if self._stream is not None:
+                    self._write_to_stream(response)
+            except connection_error_exceptions as e:
+                error = e
+            else:
+                if self._get_status_code(response) not in common.RETRYABLE:
+                    return response
+
+            if not self._retry_strategy.retry_allowed(total_sleep, num_retries):
+                # Retries are exhausted and no acceptable response was received. Raise the
+                # retriable_error or return the unacceptable response.
+                if error:
+                    raise error
+
+                return response
+
+            base_wait, wait_time = _helpers.calculate_retry_wait(
+                base_wait,
+                self._retry_strategy.max_sleep,
+                self._retry_strategy.multiplier,
+            )
+
+            num_retries += 1
+            total_sleep += wait_time
+            time.sleep(wait_time)
 
 
 class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -14,7 +14,6 @@
 
 """Support for downloading media from Google APIs."""
 
-import functools
 import urllib3.response
 
 from google.resumable_media import _download
@@ -206,9 +205,8 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             ValueError: If the current :class:`Download` has already
                 finished.
         """
-        func = functools.partial(self._consume, transport=transport, timeout=timeout)
-        return _helpers.wait_and_retry(
-            func, self._get_status_code, self._retry_strategy
+        return self._consume_with_retries(
+            self._consume, transport=transport, timeout=timeout
         )
 
 
@@ -290,7 +288,7 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
                 )
                 raise common.DataCorruption(response, msg)
 
-    def consume(
+    def _consume(
         self,
         transport,
         timeout=(
@@ -325,13 +323,11 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        result = _request_helpers.http_request(
-            transport,
+        result = transport.request(
             method,
             url,
             data=payload,
             headers=headers,
-            retry_strategy=self._retry_strategy,
             stream=True,
             timeout=timeout,
         )
@@ -342,6 +338,44 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             self._write_to_stream(result)
 
         return result
+
+    def consume(
+        self,
+        transport,
+        timeout=(
+            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
+            _request_helpers._DEFAULT_READ_TIMEOUT,
+        ),
+    ):
+        """Consume the resource to be downloaded.
+
+        This operation is retry-able based on the download HTTP response and
+        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
+        (on the current``self._retry_strategy``) returns :data:`False`.
+
+        Args:
+            transport (~requests.Session): A ``requests`` object which can
+                make authenticated requests.
+            timeout (Optional[Union[float, Tuple[float, float]]]):
+                The number of seconds to wait for the server response.
+                Depending on the retry strategy, a request may be repeated
+                several times using the same timeout each time.
+
+                Can also be passed as a tuple (connect_timeout, read_timeout).
+                See :meth:`requests.Session.request` documentation for details.
+
+        Returns:
+            ~requests.Response: The HTTP response returned by ``transport``.
+
+        Raises:
+            ~google.resumable_media.common.DataCorruption: If the download's
+                checksum doesn't agree with server-computed checksum.
+            ValueError: If the current :class:`Download` has already
+                finished.
+        """
+        return self._consume_with_retries(
+            self._consume, transport=transport, timeout=timeout
+        )
 
 
 class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload):
@@ -372,7 +406,7 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
         ValueError: If ``start`` is negative.
     """
 
-    def consume_next_chunk(
+    def _consume_next_chunk(
         self,
         transport,
         timeout=(
@@ -401,17 +435,27 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        result = _request_helpers.http_request(
-            transport,
+        result = transport.request(
             method,
             url,
             data=payload,
             headers=headers,
-            retry_strategy=self._retry_strategy,
             timeout=timeout,
         )
         self._process_response(result)
         return result
+
+    def consume_next_chunk(
+        self,
+        transport,
+        timeout=(
+            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
+            _request_helpers._DEFAULT_READ_TIMEOUT,
+        ),
+    ):
+        return self._consume_with_retries(
+            self._consume_next_chunk, transport=transport, timeout=timeout
+        )
 
 
 class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDownload):
@@ -442,7 +486,7 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
         ValueError: If ``start`` is negative.
     """
 
-    def consume_next_chunk(
+    def _consume_next_chunk(
         self,
         transport,
         timeout=(
@@ -471,18 +515,28 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        result = _request_helpers.http_request(
-            transport,
+        result = transport.request(
             method,
             url,
             data=payload,
             headers=headers,
             stream=True,
-            retry_strategy=self._retry_strategy,
             timeout=timeout,
         )
         self._process_response(result)
         return result
+
+    def consume_next_chunk(
+        self,
+        transport,
+        timeout=(
+            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
+            _request_helpers._DEFAULT_READ_TIMEOUT,
+        ),
+    ):
+        return self._consume_with_retries(
+            self._consume_next_chunk, transport=transport, timeout=timeout
+        )
 
 
 def _add_decoder(response_raw, checksum):

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -275,6 +275,26 @@ class TestDownload(object):
         # Make sure the headers have been modified.
         assert headers == {u"range": range_bytes}
 
+    def test_consume_with_retries(self):
+        download = download_mod.Download(EXAMPLE_URL)
+        transport = mock.Mock(spec=["request"])
+        response = _mock_response()
+        transport.request.return_value = response
+        ret_val = download._consume_with_retries(
+            func=download._consume,
+            transport=transport,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
+        assert ret_val is response
+        transport.request.assert_called_once_with(
+            u"GET",
+            EXAMPLE_URL,
+            data=None,
+            headers={},
+            timeout=EXPECTED_TIMEOUT,
+        )
+
 
 class TestRawDownload(object):
     def test__write_to_stream_no_hash_check(self):
@@ -528,6 +548,27 @@ class TestRawDownload(object):
         # Make sure the headers have been modified.
         assert headers == {u"range": range_bytes}
 
+    def test_consume_with_retries(self):
+        download = download_mod.RawDownload(EXAMPLE_URL)
+        transport = mock.Mock(spec=["request"])
+        response = _mock_response()
+        transport.request.return_value = response
+        ret_val = download._consume_with_retries(
+            func=download._consume,
+            transport=transport,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
+        assert ret_val is response
+        transport.request.assert_called_once_with(
+            u"GET",
+            EXAMPLE_URL,
+            data=None,
+            headers={},
+            stream=True,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
 
 class TestChunkedDownload(object):
     @staticmethod
@@ -627,6 +668,33 @@ class TestChunkedDownload(object):
             data=None,
             headers=download_headers,
             timeout=14.7,
+        )
+
+    def test_consume_with_retries(self):
+        start = 1536
+        stream = io.BytesIO()
+        data = b"Just one chunk."
+        chunk_size = len(data)
+        download = download_mod.ChunkedDownload(
+            EXAMPLE_URL, chunk_size, stream, start=start
+        )
+        total_bytes = 16384
+        transport = self._mock_transport(start, chunk_size, total_bytes, content=data)
+
+        download._consume_with_retries(
+            func=download._consume_next_chunk,
+            transport=transport,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
+        range_bytes = u"bytes={:d}-{:d}".format(start, start + chunk_size - 1)
+        download_headers = {u"range": range_bytes}
+        transport.request.assert_called_once_with(
+            u"GET",
+            EXAMPLE_URL,
+            data=None,
+            headers=download_headers,
+            timeout=EXPECTED_TIMEOUT,
         )
 
 
@@ -736,6 +804,34 @@ class TestRawChunkedDownload(object):
         assert not download.finished
         assert download.bytes_downloaded == chunk_size
         assert download.total_bytes == total_bytes
+
+    def test_consume_with_retries(self):
+        start = 1536
+        stream = io.BytesIO()
+        data = b"Just one chunk."
+        chunk_size = len(data)
+        download = download_mod.RawChunkedDownload(
+            EXAMPLE_URL, chunk_size, stream, start=start
+        )
+        total_bytes = 16384
+        transport = self._mock_transport(start, chunk_size, total_bytes, content=data)
+
+        download._consume_with_retries(
+            func=download._consume_next_chunk,
+            transport=transport,
+            timeout=EXPECTED_TIMEOUT,
+        )
+
+        range_bytes = u"bytes={:d}-{:d}".format(start, start + chunk_size - 1)
+        download_headers = {u"range": range_bytes}
+        transport.request.assert_called_once_with(
+            u"GET",
+            EXAMPLE_URL,
+            data=None,
+            headers=download_headers,
+            stream=True,
+            timeout=EXPECTED_TIMEOUT,
+        )
 
 
 class Test__add_decoder(object):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -270,6 +270,34 @@ class Test_wait_and_retry(object):
 
     @mock.patch(u"time.sleep")
     @mock.patch(u"random.randint")
+    def test_success_with_retry_chunked_encoding_error(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [125, 625, 375]
+
+        response = _make_response(http_client.NOT_FOUND)
+        responses = [
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ChunkedEncodingError,
+            response,
+        ]
+        func = mock.Mock(side_effect=responses, spec=[])
+
+        retry_strategy = common.RetryStrategy()
+        ret_val = _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
+
+        assert ret_val == responses[-1]
+
+        assert func.call_count == 3
+        assert func.mock_calls == [mock.call()] * 3
+
+        assert randint_mock.call_count == 2
+        assert randint_mock.mock_calls == [mock.call(0, 1000)] * 2
+
+        assert sleep_mock.call_count == 2
+        sleep_mock.assert_any_call(1.125)
+        sleep_mock.assert_any_call(2.625)
+
+    @mock.patch(u"time.sleep")
+    @mock.patch(u"random.randint")
     def test_connection_import_error_failure(self, randint_mock, sleep_mock):
         randint_mock.side_effect = [125, 625, 375]
 


### PR DESCRIPTION
This broadens the retry coverage in downloads to cover both the initial response (receiving/evaluating http headers) and the streaming/writing to file portion of the download.  

- Modifies the original `consume()` method to an internal method `_consume()` and replace the retry-able http request to a raw http request
- Adds an internal method `consume_with_retries()` within classes `Download` and `ChunkedDownload` that will attempt to retry a callable `_consume()` until success
- Updates tests and docstrings

Fixes #240 