### PR TITLE
revert: revert "fix: add retry coverage to the streaming portion of a download"

### DIFF
--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -15,7 +15,6 @@
 """Virtual bases classes for downloading media from Google APIs."""
 
 
-import functools
 import re
 
 from six.moves import http_client
@@ -208,37 +207,6 @@ class Download(DownloadBase):
             NotImplementedError: Always, since virtual.
         """
         raise NotImplementedError(u"This implementation is virtual.")
-
-    def _consume_with_retries(self, func, transport, timeout=None):
-        """Attempts to retry a download and consume until success.
-
-        The consume ``func`` is retry-able based on the HTTP response and
-        connection error type. Retry covers both the initial response and
-        the streaming portion of the download.
-
-        Will retry until :meth:`~.RetryStrategy.retry_allowed` (on the current
-        ``retry_strategy``) returns :data:`False`.
-
-        Args:
-            func (Callable): A callable that takes no arguments and produces
-                an HTTP response which will be checked as retry-able.
-            transport (object): An object which can make authenticated
-                requests.
-            timeout (Optional[Union[float, Tuple[float, float]]]):
-                The number of seconds to wait for the server response.
-                Depending on the retry strategy, a request may be repeated
-                several times using the same timeout each time.
-
-                Can also be passed as a tuple (connect_timeout, read_timeout).
-                See :meth:`requests.Session.request` documentation for details.
-
-        Returns:
-            ~requests.Response: The return value of ``transport.request()``.
-        """
-        func_to_retry = functools.partial(func, transport=transport, timeout=timeout)
-        return _helpers.wait_and_retry(
-            func_to_retry, self._get_status_code, self._retry_strategy
-        )
 
 
 class ChunkedDownload(DownloadBase):
@@ -470,37 +438,6 @@ class ChunkedDownload(DownloadBase):
             NotImplementedError: Always, since virtual.
         """
         raise NotImplementedError(u"This implementation is virtual.")
-
-    def _consume_with_retries(self, func, transport, timeout=None):
-        """Attempts to retry a consume_next_chunk until success.
-
-        The consume_next_chunk ``func`` is retry-able based on the HTTP response
-        and connection error type. Retry covers both the initial response and
-        the streaming portion of the download.
-
-        Will retry until :meth:`~.RetryStrategy.retry_allowed` (on the current
-        ``retry_strategy``) returns :data:`False`.
-
-        Args:
-            func (Callable): A callable that takes no arguments and produces
-                an HTTP response which will be checked as retry-able.
-            transport (object): An object which can make authenticated
-                requests.
-            timeout (Optional[Union[float, Tuple[float, float]]]):
-                The number of seconds to wait for the server response.
-                Depending on the retry strategy, a request may be repeated
-                several times using the same timeout each time.
-
-                Can also be passed as a tuple (connect_timeout, read_timeout).
-                See :meth:`requests.Session.request` documentation for details.
-
-        Returns:
-            ~requests.Response: The return value of ``transport.request()``.
-        """
-        func_to_retry = functools.partial(func, transport=transport, timeout=timeout)
-        return _helpers.wait_and_retry(
-            func_to_retry, self._get_status_code, self._retry_strategy
-        )
 
 
 def add_bytes_range(start, end, headers):

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -119,7 +119,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
                 )
                 raise common.DataCorruption(response, msg)
 
-    def _consume(
+    def consume(
         self,
         transport,
         timeout=(
@@ -127,10 +127,10 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the resource to be downloaded without any retries.
+        """Consume the resource to be downloaded.
 
-        This is intended to be called by :meth:`consume` so it can be
-        wrapped with error handling and retry strategy.
+        If a ``stream`` is attached to this download, then the downloaded
+        resource will be written to the stream.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -157,12 +157,13 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
         request_kwargs = {
             u"data": payload,
             u"headers": headers,
+            u"retry_strategy": self._retry_strategy,
             u"timeout": timeout,
         }
         if self._stream is not None:
             request_kwargs[u"stream"] = True
 
-        result = transport.request(method, url, **request_kwargs)
+        result = _request_helpers.http_request(transport, method, url, **request_kwargs)
 
         self._process_response(result)
 
@@ -170,47 +171,6 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             self._write_to_stream(result)
 
         return result
-
-    def consume(
-        self,
-        transport,
-        timeout=(
-            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
-            _request_helpers._DEFAULT_READ_TIMEOUT,
-        ),
-    ):
-        """Consume the resource to be downloaded.
-
-        If a ``stream`` is attached to this download, then the downloaded
-        resource will be written to the stream.
-
-        This operation is retry-able based on the download HTTP response and
-        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
-        (on the current``self._retry_strategy``) returns :data:`False`.
-
-        Args:
-            transport (~requests.Session): A ``requests`` object which can
-                make authenticated requests.
-            timeout (Optional[Union[float, Tuple[float, float]]]):
-                The number of seconds to wait for the server response.
-                Depending on the retry strategy, a request may be repeated
-                several times using the same timeout each time.
-
-                Can also be passed as a tuple (connect_timeout, read_timeout).
-                See :meth:`requests.Session.request` documentation for details.
-
-        Returns:
-            ~requests.Response: The HTTP response returned by ``transport``.
-
-        Raises:
-            ~google.resumable_media.common.DataCorruption: If the download's
-                checksum doesn't agree with server-computed checksum.
-            ValueError: If the current :class:`Download` has already
-                finished.
-        """
-        return self._consume_with_retries(
-            self._consume, transport=transport, timeout=timeout
-        )
 
 
 class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
@@ -291,7 +251,7 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
                 )
                 raise common.DataCorruption(response, msg)
 
-    def _consume(
+    def consume(
         self,
         transport,
         timeout=(
@@ -299,10 +259,10 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the resource to be downloaded without any retries.
+        """Consume the resource to be downloaded.
 
-        This is intended to be called by :meth:`consume` so it can be
-        wrapped with error handling and retry strategy.
+        If a ``stream`` is attached to this download, then the downloaded
+        resource will be written to the stream.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -326,11 +286,13 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        result = transport.request(
+        result = _request_helpers.http_request(
+            transport,
             method,
             url,
             data=payload,
             headers=headers,
+            retry_strategy=self._retry_strategy,
             stream=True,
             timeout=timeout,
         )
@@ -341,47 +303,6 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             self._write_to_stream(result)
 
         return result
-
-    def consume(
-        self,
-        transport,
-        timeout=(
-            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
-            _request_helpers._DEFAULT_READ_TIMEOUT,
-        ),
-    ):
-        """Consume the resource to be downloaded.
-
-        If a ``stream`` is attached to this download, then the downloaded
-        resource will be written to the stream.
-
-        This operation is retry-able based on the download HTTP response and
-        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
-        (on the current``self._retry_strategy``) returns :data:`False`.
-
-        Args:
-            transport (~requests.Session): A ``requests`` object which can
-                make authenticated requests.
-            timeout (Optional[Union[float, Tuple[float, float]]]):
-                The number of seconds to wait for the server response.
-                Depending on the retry strategy, a request may be repeated
-                several times using the same timeout each time.
-
-                Can also be passed as a tuple (connect_timeout, read_timeout).
-                See :meth:`requests.Session.request` documentation for details.
-
-        Returns:
-            ~requests.Response: The HTTP response returned by ``transport``.
-
-        Raises:
-            ~google.resumable_media.common.DataCorruption: If the download's
-                checksum doesn't agree with server-computed checksum.
-            ValueError: If the current :class:`Download` has already
-                finished.
-        """
-        return self._consume_with_retries(
-            self._consume, transport=transport, timeout=timeout
-        )
 
 
 class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload):
@@ -412,7 +333,7 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
         ValueError: If ``start`` is negative.
     """
 
-    def _consume_next_chunk(
+    def consume_next_chunk(
         self,
         transport,
         timeout=(
@@ -420,10 +341,7 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the next chunk of the resource to be downloaded without any retries.
-
-        This is intended to be called by :meth:`consume_next_chunk` so it can be
-        wrapped with error handling and retry strategy.
+        """Consume the next chunk of the resource to be downloaded.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -444,47 +362,17 @@ class ChunkedDownload(_request_helpers.RequestsMixin, _download.ChunkedDownload)
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        result = transport.request(
+        result = _request_helpers.http_request(
+            transport,
             method,
             url,
             data=payload,
             headers=headers,
+            retry_strategy=self._retry_strategy,
             timeout=timeout,
         )
         self._process_response(result)
         return result
-
-    def consume_next_chunk(
-        self,
-        transport,
-        timeout=(
-            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
-            _request_helpers._DEFAULT_READ_TIMEOUT,
-        ),
-    ):
-        """Consume the next chunk of the resource to be downloaded.
-
-        This operation is retry-able based on the download HTTP response and
-        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
-        (on the current``self._retry_strategy``) returns :data:`False`.
-
-        Args:
-            transport (~requests.Session): A ``requests`` object which can
-                make authenticated requests.
-            timeout (Optional[Union[float, Tuple[float, float]]]):
-                The number of seconds to wait for the server response.
-                Depending on the retry strategy, a request may be repeated
-                several times using the same timeout each time.
-                Can also be passed as a tuple (connect_timeout, read_timeout).
-                See :meth:`requests.Session.request` documentation for details.
-        Returns:
-            ~requests.Response: The HTTP response returned by ``transport``.
-        Raises:
-            ValueError: If the current download has finished.
-        """
-        return self._consume_with_retries(
-            self._consume_next_chunk, transport=transport, timeout=timeout
-        )
 
 
 class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDownload):
@@ -515,7 +403,7 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
         ValueError: If ``start`` is negative.
     """
 
-    def _consume_next_chunk(
+    def consume_next_chunk(
         self,
         transport,
         timeout=(
@@ -523,10 +411,7 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
             _request_helpers._DEFAULT_READ_TIMEOUT,
         ),
     ):
-        """Consume the next chunk of the resource to be downloaded without any retries.
-
-        This is intended to be called by :meth:`consume_next_chunk` so it can be
-        wrapped with error handling and retry strategy.
+        """Consume the next chunk of the resource to be downloaded.
 
         Args:
             transport (~requests.Session): A ``requests`` object which can
@@ -547,48 +432,18 @@ class RawChunkedDownload(_request_helpers.RawRequestsMixin, _download.ChunkedDow
         """
         method, url, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
-        result = transport.request(
+        result = _request_helpers.http_request(
+            transport,
             method,
             url,
             data=payload,
             headers=headers,
             stream=True,
+            retry_strategy=self._retry_strategy,
             timeout=timeout,
         )
         self._process_response(result)
         return result
-
-    def consume_next_chunk(
-        self,
-        transport,
-        timeout=(
-            _request_helpers._DEFAULT_CONNECT_TIMEOUT,
-            _request_helpers._DEFAULT_READ_TIMEOUT,
-        ),
-    ):
-        """Consume the next chunk of the resource to be downloaded.
-
-        This operation is retry-able based on the download HTTP response and
-        connection error type. Will retry until :meth:`~.RetryStrategy.retry_allowed`
-        (on the current``self._retry_strategy``) returns :data:`False`.
-
-        Args:
-            transport (~requests.Session): A ``requests`` object which can
-                make authenticated requests.
-            timeout (Optional[Union[float, Tuple[float, float]]]):
-                The number of seconds to wait for the server response.
-                Depending on the retry strategy, a request may be repeated
-                several times using the same timeout each time.
-                Can also be passed as a tuple (connect_timeout, read_timeout).
-                See :meth:`requests.Session.request` documentation for details.
-        Returns:
-            ~requests.Response: The HTTP response returned by ``transport``.
-        Raises:
-            ValueError: If the current download has finished.
-        """
-        return self._consume_with_retries(
-            self._consume_next_chunk, transport=transport, timeout=timeout
-        )
 
 
 def _add_decoder(response_raw, checksum):

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -275,26 +275,6 @@ class TestDownload(object):
         # Make sure the headers have been modified.
         assert headers == {u"range": range_bytes}
 
-    def test_consume_with_retries(self):
-        download = download_mod.Download(EXAMPLE_URL)
-        transport = mock.Mock(spec=["request"])
-        response = _mock_response()
-        transport.request.return_value = response
-        ret_val = download._consume_with_retries(
-            func=download._consume,
-            transport=transport,
-            timeout=EXPECTED_TIMEOUT,
-        )
-
-        assert ret_val is response
-        transport.request.assert_called_once_with(
-            u"GET",
-            EXAMPLE_URL,
-            data=None,
-            headers={},
-            timeout=EXPECTED_TIMEOUT,
-        )
-
 
 class TestRawDownload(object):
     def test__write_to_stream_no_hash_check(self):
@@ -548,27 +528,6 @@ class TestRawDownload(object):
         # Make sure the headers have been modified.
         assert headers == {u"range": range_bytes}
 
-    def test_consume_with_retries(self):
-        download = download_mod.RawDownload(EXAMPLE_URL)
-        transport = mock.Mock(spec=["request"])
-        response = _mock_response()
-        transport.request.return_value = response
-        ret_val = download._consume_with_retries(
-            func=download._consume,
-            transport=transport,
-            timeout=EXPECTED_TIMEOUT,
-        )
-
-        assert ret_val is response
-        transport.request.assert_called_once_with(
-            u"GET",
-            EXAMPLE_URL,
-            data=None,
-            headers={},
-            stream=True,
-            timeout=EXPECTED_TIMEOUT,
-        )
-
 
 class TestChunkedDownload(object):
     @staticmethod
@@ -668,33 +627,6 @@ class TestChunkedDownload(object):
             data=None,
             headers=download_headers,
             timeout=14.7,
-        )
-
-    def test_consume_with_retries(self):
-        start = 1536
-        stream = io.BytesIO()
-        data = b"Just one chunk."
-        chunk_size = len(data)
-        download = download_mod.ChunkedDownload(
-            EXAMPLE_URL, chunk_size, stream, start=start
-        )
-        total_bytes = 16384
-        transport = self._mock_transport(start, chunk_size, total_bytes, content=data)
-
-        download._consume_with_retries(
-            func=download._consume_next_chunk,
-            transport=transport,
-            timeout=EXPECTED_TIMEOUT,
-        )
-
-        range_bytes = u"bytes={:d}-{:d}".format(start, start + chunk_size - 1)
-        download_headers = {u"range": range_bytes}
-        transport.request.assert_called_once_with(
-            u"GET",
-            EXAMPLE_URL,
-            data=None,
-            headers=download_headers,
-            timeout=EXPECTED_TIMEOUT,
         )
 
 
@@ -804,34 +736,6 @@ class TestRawChunkedDownload(object):
         assert not download.finished
         assert download.bytes_downloaded == chunk_size
         assert download.total_bytes == total_bytes
-
-    def test_consume_with_retries(self):
-        start = 1536
-        stream = io.BytesIO()
-        data = b"Just one chunk."
-        chunk_size = len(data)
-        download = download_mod.RawChunkedDownload(
-            EXAMPLE_URL, chunk_size, stream, start=start
-        )
-        total_bytes = 16384
-        transport = self._mock_transport(start, chunk_size, total_bytes, content=data)
-
-        download._consume_with_retries(
-            func=download._consume_next_chunk,
-            transport=transport,
-            timeout=EXPECTED_TIMEOUT,
-        )
-
-        range_bytes = u"bytes={:d}-{:d}".format(start, start + chunk_size - 1)
-        download_headers = {u"range": range_bytes}
-        transport.request.assert_called_once_with(
-            u"GET",
-            EXAMPLE_URL,
-            data=None,
-            headers=download_headers,
-            stream=True,
-            timeout=EXPECTED_TIMEOUT,
-        )
 
 
 class Test__add_decoder(object):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -270,34 +270,6 @@ class Test_wait_and_retry(object):
 
     @mock.patch(u"time.sleep")
     @mock.patch(u"random.randint")
-    def test_success_with_retry_chunked_encoding_error(self, randint_mock, sleep_mock):
-        randint_mock.side_effect = [125, 625, 375]
-
-        response = _make_response(http_client.NOT_FOUND)
-        responses = [
-            requests.exceptions.ChunkedEncodingError,
-            requests.exceptions.ChunkedEncodingError,
-            response,
-        ]
-        func = mock.Mock(side_effect=responses, spec=[])
-
-        retry_strategy = common.RetryStrategy()
-        ret_val = _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
-
-        assert ret_val == responses[-1]
-
-        assert func.call_count == 3
-        assert func.mock_calls == [mock.call()] * 3
-
-        assert randint_mock.call_count == 2
-        assert randint_mock.mock_calls == [mock.call(0, 1000)] * 2
-
-        assert sleep_mock.call_count == 2
-        sleep_mock.assert_any_call(1.125)
-        sleep_mock.assert_any_call(2.625)
-
-    @mock.patch(u"time.sleep")
-    @mock.patch(u"random.randint")
     def test_connection_import_error_failure(self, randint_mock, sleep_mock):
         randint_mock.side_effect = [125, 625, 375]
 


### PR DESCRIPTION
Reverts #241

Errors caught in conformance testing. Retries are not working as intended with an entire retry block. Working on a new fix to apply retry strategy separately to the initial response and the streaming portion of a download. 