### PR TITLE
fix: upload download instances are not marked invalid with retriable error codes

### DIFF
--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -192,17 +192,17 @@ def wait_and_retry(func, get_status_code, retry_strategy):
         else:
             return response
 
-        if not retry_strategy.retry_allowed(total_sleep, num_retries):
-            # Retries are exhausted and no acceptable response was received.
-            # Raise the retriable_error.
-            raise error
-
         base_wait, wait_time = calculate_retry_wait(
             base_wait, retry_strategy.max_sleep, retry_strategy.multiplier
         )
-
         num_retries += 1
         total_sleep += wait_time
+
+        # Check if (another) retry is allowed. If retries are exhausted and
+        # no acceptable response was received, raise the retriable error.
+        if not retry_strategy.retry_allowed(total_sleep, num_retries):
+            raise error
+
         time.sleep(wait_time)
 
 

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -95,7 +95,8 @@ def require_status_code(response, status_codes, get_status_code, callback=do_not
     """
     status_code = get_status_code(response)
     if status_code not in status_codes:
-        callback()
+        if status_code not in common.RETRYABLE:
+            callback()
         raise common.InvalidResponse(
             response,
             "Request failed with status code",

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -337,7 +337,7 @@ class Test_wait_and_retry(object):
     @mock.patch("time.sleep")
     @mock.patch("random.randint")
     def test_retry_exceeds_max_cumulative(self, randint_mock, sleep_mock):
-        randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125, 0]
+        randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
 
         status_codes = (
             http.client.SERVICE_UNAVAILABLE,
@@ -346,7 +346,6 @@ class Test_wait_and_retry(object):
             http.client.INTERNAL_SERVER_ERROR,
             http.client.SERVICE_UNAVAILABLE,
             http.client.BAD_GATEWAY,
-            http.client.GATEWAY_TIMEOUT,
             common.TOO_MANY_REQUESTS,
         )
         responses = [_make_response(status_code) for status_code in status_codes]
@@ -365,47 +364,75 @@ class Test_wait_and_retry(object):
         assert ret_val.status_code == status_codes[-1]
         assert status_codes[-1] in common.RETRYABLE
 
-        assert func.call_count == 8
-        assert func.mock_calls == [mock.call()] * 8
+        assert func.call_count == 7
+        assert func.mock_calls == [mock.call()] * 7
 
         assert randint_mock.call_count == 7
         assert randint_mock.mock_calls == [mock.call(0, 1000)] * 7
 
-        assert sleep_mock.call_count == 7
+        assert sleep_mock.call_count == 6
         sleep_mock.assert_any_call(1.875)
         sleep_mock.assert_any_call(2.0)
         sleep_mock.assert_any_call(4.375)
         sleep_mock.assert_any_call(8.5)
         sleep_mock.assert_any_call(16.5)
         sleep_mock.assert_any_call(32.25)
-        sleep_mock.assert_any_call(64.125)
+
+    @mock.patch("time.sleep")
+    @mock.patch("random.randint")
+    def test_retry_exceeds_num_retries(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [875, 0, 375]
+
+        status_codes = (
+            http.client.SERVICE_UNAVAILABLE,
+            http.client.GATEWAY_TIMEOUT,
+            common.TOO_MANY_REQUESTS,
+        )
+        responses = [_make_response(status_code) for status_code in status_codes]
+
+        def raise_response():
+            raise common.InvalidResponse(responses.pop(0))
+
+        func = mock.Mock(side_effect=raise_response)
+
+        retry_strategy = common.RetryStrategy(max_retries=0)
+        try:
+            _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
+        except common.InvalidResponse as e:
+            ret_val = e.response
+
+        assert func.call_count == 1
+        assert func.mock_calls == [mock.call()] * 1
+        assert ret_val.status_code == status_codes[0]
+
+        assert randint_mock.call_count == 1
+        assert sleep_mock.call_count == 0
 
     @mock.patch("time.sleep")
     @mock.patch("random.randint")
     def test_retry_exceeded_reraises_connection_error(self, randint_mock, sleep_mock):
         randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
 
-        responses = [requests.exceptions.ConnectionError] * 8
+        responses = [requests.exceptions.ConnectionError] * 7
         func = mock.Mock(side_effect=responses, spec=[])
 
         retry_strategy = common.RetryStrategy(max_cumulative_retry=100.0)
         with pytest.raises(requests.exceptions.ConnectionError):
             _helpers.wait_and_retry(func, _get_status_code, retry_strategy)
 
-        assert func.call_count == 8
-        assert func.mock_calls == [mock.call()] * 8
+        assert func.call_count == 7
+        assert func.mock_calls == [mock.call()] * 7
 
         assert randint_mock.call_count == 7
         assert randint_mock.mock_calls == [mock.call(0, 1000)] * 7
 
-        assert sleep_mock.call_count == 7
+        assert sleep_mock.call_count == 6
         sleep_mock.assert_any_call(1.875)
         sleep_mock.assert_any_call(2.0)
         sleep_mock.assert_any_call(4.375)
         sleep_mock.assert_any_call(8.5)
         sleep_mock.assert_any_call(16.5)
         sleep_mock.assert_any_call(32.25)
-        sleep_mock.assert_any_call(64.125)
 
 
 def _make_response(status_code):


### PR DESCRIPTION
`ResumableUpload` and `ChunkedDownload` can retry when it is safe to do so (encountering retriable error codes and specify preconditions if needed). The instance should not be marked as invalid if it encounters a retriable status code.

Update helper method `require_status_code()` to only make an instance invalid with non-retriable error codes.