### PR TITLE
fix: pin google-crc32c to 1.1.2 to mitigate issue on OS X Big Sur

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 
 REQUIREMENTS = [
-    'google-crc32c >= 1.0, < 2.0dev',
+    'google-crc32c >= 1.0, <= 1.1.2',
 ]
 EXTRAS_REQUIRE = {
     'requests': [


### PR DESCRIPTION
This pin avoids a google-crc32c segmentation fault for OS X Big Sur users that eluded CI (which is running an older version of OS X). Pin can be removed once google-crc32c is fixed for OS X Big Sur.