### PR TITLE
chore: update release_level in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,6 +8,5 @@
     "repo": "googleapis/google-resumable-media-python",
     "distribution_name": "google-resumable-media",
     "default_version": "",
-    "codeowner_team": "@googleapis/cloud-storage-dpe",
-    "api_shortname": "google-resumable-media"
+    "codeowner_team": "@googleapis/cloud-storage-dpe"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,12 +1,13 @@
 {
     "name": "google-resumable-media",
     "name_pretty": "Google Resumable Media",
-    "client_documentation": "https://googleapis.dev/python/google-resumable-media/latest/index.html",
-    "release_level": "alpha",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/google-resumable-media/latest",
+    "release_level": "preview",
     "language": "python",
     "library_type": "CORE",
     "repo": "googleapis/google-resumable-media-python",
     "distribution_name": "google-resumable-media",
     "default_version": "",
-    "codeowner_team": "@googleapis/cloud-storage-dpe"
+    "codeowner_team": "@googleapis/cloud-storage-dpe",
+    "api_shortname": "google-resumable-media"
 }


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 