### PR TITLE
feat: safely resume interrupted downloads

### DIFF
--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -144,21 +144,6 @@ class Download(DownloadBase):
         self._checksum_object = None
         self._object_generation = None
 
-    @property
-    def bytes_downloaded(self):
-        """int: Number of bytes that have been downloaded."""
-        return self._bytes_downloaded
-
-    @property
-    def expected_checksum(self):
-        """str: The expected checksum of the response detected from the ``X-Goog-Hash`` header."""
-        return self._expected_checksum
-
-    @property
-    def checksum_object(self):
-        """object: The checksum object for the appropriate checksum type."""
-        return self._checksum_object
-
     def _prepare_request(self):
         """Prepare the contents of an HTTP request.
 

--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -18,13 +18,6 @@
 import http.client
 import re
 
-from urllib.parse import parse_qs
-from urllib.parse import parse_qsl
-from urllib.parse import urlencode
-from urllib.parse import urlsplit
-from urllib.parse import urlunsplit
-
-
 from google.resumable_media import _helpers
 from google.resumable_media import common
 
@@ -579,43 +572,3 @@ def _check_for_zero_content_range(response, get_status_code, get_headers):
         if content_range == _ZERO_CONTENT_RANGE_HEADER:
             return True
     return False
-
-
-def generation_in_media_url(media_url):
-    """Retrieve the object generation query param specified in media url.
-
-    Args:
-        media_url (str): The URL containing the media to be downloaded.
-
-    Returns:
-        long: The object generation from the media url if exists, else None.
-    """
-
-    _, _, _, query, _ = urlsplit(media_url)
-    query_params = parse_qs(query)
-    object_generation = query_params.get("generation", None)
-
-    if object_generation is not None:
-        return int(object_generation[0])
-
-    return object_generation
-
-
-def add_query_parameters(media_url, name_value_pairs):
-    """Add query parameters to a base url.
-
-    Args:
-        media_url (str): The URL containing the media to be downloaded.
-        name_value_pairs (list[tuple[str, str]): Names and values of the query parameters to add.
-
-    Returns:
-        str: URL with additional query strings appended.
-    """
-
-    if len(name_value_pairs) == 0:
-        return media_url
-
-    scheme, netloc, path, query, frag = urlsplit(media_url)
-    query = parse_qsl(query)
-    query.extend(name_value_pairs)
-    return urlunsplit((scheme, netloc, path, urlencode(query), frag))

--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -581,20 +581,24 @@ def _check_for_zero_content_range(response, get_status_code, get_headers):
     return False
 
 
-def query_param_in_media_url(media_url, query_param):
-    """Retrieve query parameter specified in media url.
+def generation_in_media_url(media_url):
+    """Retrieve the object generation query param specified in media url.
 
     Args:
         media_url (str): The URL containing the media to be downloaded.
-        query_param (str): The query parameter name to retrieve.
 
     Returns:
-        str: The query parameter value from the media url if exists, else None.
+        long: The object generation from the media url if exists, else None.
     """
 
     _, _, _, query, _ = urlsplit(media_url)
-    queries = parse_qs(query)
-    return queries.get(query_param, None)
+    query_params = parse_qs(query)
+    object_generation = query_params.get("generation", None)
+
+    if object_generation is not None:
+        return int(object_generation)
+
+    return object_generation
 
 
 def add_query_parameters(media_url, name_value_pairs):

--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -596,7 +596,7 @@ def generation_in_media_url(media_url):
     object_generation = query_params.get("generation", None)
 
     if object_generation is not None:
-        return int(object_generation)
+        return int(object_generation[0])
 
     return object_generation
 

--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -139,6 +139,24 @@ class Download(DownloadBase):
             media_url, stream=stream, start=start, end=end, headers=headers
         )
         self.checksum = checksum
+        self._bytes_downloaded = 0
+        self._expected_checksum = None
+        self._checksum_object = None
+
+    @property
+    def bytes_downloaded(self):
+        """int: Number of bytes that have been downloaded."""
+        return self._bytes_downloaded
+
+    @property
+    def expected_checksum(self):
+        """str: The expected checksum of the response detected from the ``X-Goog-Hash`` header."""
+        return self._expected_checksum
+
+    @property
+    def checksum_object(self):
+        """object: The checksum object for the appropriate checksum type."""
+        return self._checksum_object
 
     def _prepare_request(self):
         """Prepare the contents of an HTTP request.

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -38,7 +38,6 @@ _SLOW_CRC32C_WARNING = (
     "implementation. Python 3 has a faster implementation, `google-crc32c`, "
     "which will be used if it is installed."
 )
-_CONTENT_ENCODING_HEADER = "Content-Encoding"
 _GENERATION_HEADER = "x-goog-generation"
 _HASH_HEADER = "x-goog-hash"
 _MISSING_CHECKSUM = """\
@@ -368,21 +367,6 @@ def add_query_parameters(media_url, query_params):
     new_params = {**params, **query_params}
     query = urlencode(new_params, doseq=True)
     return urlunsplit((scheme, netloc, path, query, frag))
-
-
-def _is_decompressive_transcoding(response, get_headers):
-    """Returns True if the object was served decompressed and the "Content-Encoding" header is "gzip".
-       See more at: https://cloud.google.com/storage/docs/transcoding#transcoding_and_gzip
-
-    Args:
-        response (~requests.Response): The HTTP response object.
-        get_headers (callable: response->dict): returns response headers.
-
-    Returns:
-        bool: Returns True if the "Content-Encoding" header is "gzip"; otherwise, False.
-    """
-    headers = get_headers(response)
-    return headers.get(_CONTENT_ENCODING_HEADER) == "gzip"
 
 
 class _DoNothingHash(object):

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -33,6 +33,7 @@ _SLOW_CRC32C_WARNING = (
     "implementation. Python 3 has a faster implementation, `google-crc32c`, "
     "which will be used if it is installed."
 )
+_CONTENT_ENCODING_HEADER = "Content-Encoding"
 _HASH_HEADER = "x-goog-hash"
 _GENERATION_HEADER = "x-goog-generation"
 _MISSING_CHECKSUM = """\
@@ -322,6 +323,21 @@ def _parse_generation_header(response, get_headers):
         return int(object_generation)
 
     return object_generation
+
+
+def _is_decompressive_transcoding(response, get_headers):
+    """Returns True if the object was served decompressed and the "Content-Encoding" header is "gzip".
+       See more at: https://cloud.google.com/storage/docs/transcoding#transcoding_and_gzip
+
+    Args:
+        response (~requests.Response): The HTTP response object.
+        get_headers (callable: response->dict): returns response headers.
+
+    Returns:
+        bool: Returns True if the "Content-Encoding" header is "gzip"; otherwise, False.
+    """
+    headers = get_headers(response)
+    return headers.get(_CONTENT_ENCODING_HEADER) == "gzip"
 
 
 class _DoNothingHash(object):

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -34,6 +34,7 @@ _SLOW_CRC32C_WARNING = (
     "which will be used if it is installed."
 )
 _HASH_HEADER = "x-goog-hash"
+_GENERATION_HEADER = "x-goog-generation"
 _MISSING_CHECKSUM = """\
 No {checksum_type} checksum was returned from the service while downloading {}
 (which happens for composite objects), so client-side content integrity
@@ -300,6 +301,27 @@ def _get_checksum_object(checksum_type):
         return None
     else:
         raise ValueError("checksum must be ``'md5'``, ``'crc32c'`` or ``None``")
+
+
+def _parse_generation_header(response, get_headers):
+    """Parses the generation header from an ``X-Goog-Generation`` value.
+
+    Args:
+        response (~requests.Response): The HTTP response object.
+        get_headers (callable: response->dict): returns response headers.
+
+
+    Returns:
+        Optional[long]: The object generation from the response, if it
+        can be detected from the ``X-Goog-Generation`` header; otherwise, None.
+    """
+    headers = get_headers(response)
+    object_generation = headers.get(_GENERATION_HEADER, None)
+
+    if object_generation:
+        return int(object_generation)
+
+    return object_generation
 
 
 class _DoNothingHash(object):

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -40,8 +40,8 @@ _SLOW_CRC32C_WARNING = (
     "which will be used if it is installed."
 )
 _CONTENT_ENCODING_HEADER = "Content-Encoding"
-_HASH_HEADER = "x-goog-hash"
 _GENERATION_HEADER = "x-goog-generation"
+_HASH_HEADER = "x-goog-hash"
 _MISSING_CHECKSUM = """\
 No {checksum_type} checksum was returned from the service while downloading {}
 (which happens for composite objects), so client-side content integrity
@@ -317,7 +317,6 @@ def _parse_generation_header(response, get_headers):
         response (~requests.Response): The HTTP response object.
         get_headers (callable: response->dict): returns response headers.
 
-
     Returns:
         Optional[long]: The object generation from the response, if it
         can be detected from the ``X-Goog-Generation`` header; otherwise, None.
@@ -325,10 +324,10 @@ def _parse_generation_header(response, get_headers):
     headers = get_headers(response)
     object_generation = headers.get(_GENERATION_HEADER, None)
 
-    if object_generation:
+    if object_generation is None:
+        return None
+    else:
         return int(object_generation)
-
-    return object_generation
 
 
 def _get_generation_from_url(media_url):
@@ -345,10 +344,10 @@ def _get_generation_from_url(media_url):
     query_params = parse_qs(query)
     object_generation = query_params.get("generation", None)
 
-    if object_generation is not None:
+    if object_generation is None:
+        return None
+    else:
         return int(object_generation[0])
-
-    return object_generation
 
 
 def add_query_parameters(media_url, name_value_pairs):

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -23,7 +23,6 @@ import random
 import warnings
 
 from urllib.parse import parse_qs
-from urllib.parse import parse_qsl
 from urllib.parse import urlencode
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
@@ -350,24 +349,25 @@ def _get_generation_from_url(media_url):
         return int(object_generation[0])
 
 
-def add_query_parameters(media_url, name_value_pairs):
+def add_query_parameters(media_url, query_params):
     """Add query parameters to a base url.
 
     Args:
         media_url (str): The URL containing the media to be downloaded.
-        name_value_pairs (list[tuple[str, str]]): Names and values of the query parameters to add.
+        query_params (dict): Names and values of the query parameters to add.
 
     Returns:
         str: URL with additional query strings appended.
     """
 
-    if len(name_value_pairs) == 0:
+    if len(query_params) == 0:
         return media_url
 
     scheme, netloc, path, query, frag = urlsplit(media_url)
-    query = parse_qsl(query)
-    query.extend(name_value_pairs)
-    return urlunsplit((scheme, netloc, path, urlencode(query), frag))
+    params = parse_qs(query)
+    new_params = {**params, **query_params}
+    query = urlencode(new_params, doseq=True)
+    return urlunsplit((scheme, netloc, path, query, frag))
 
 
 def _is_decompressive_transcoding(response, get_headers):

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -90,7 +90,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
         # then compute and validate the checksum when the full download completes.
         # Retried requests are range requests, and there's no way to detect
         # data corruption for that byte range alone.
-        if self.expected_checksum is None and self.checksum_object is None:
+        if self._expected_checksum is None and self._checksum_object is None:
             # `_get_expected_checksum()` may return None even if a checksum was
             # requested, in which case it will emit an info log _MISSING_CHECKSUM.
             # If an invalid checksum type is specified, this will raise ValueError.
@@ -100,8 +100,8 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             self._expected_checksum = expected_checksum
             self._checksum_object = checksum_object
         else:
-            expected_checksum = self.expected_checksum
-            checksum_object = self.checksum_object
+            expected_checksum = self._expected_checksum
+            checksum_object = self._checksum_object
 
         with response:
             # NOTE: In order to handle compressed streams gracefully, we try
@@ -171,7 +171,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
         if self._stream is not None:
             request_kwargs["stream"] = True
 
-        # Assign object generation if generation is specified in the media url
+        # Assign object generation if generation is specified in the media url.
         self._object_generation = _helpers._get_generation_from_url(self.media_url)
 
         # Wrap the request business logic in a function to be retried.
@@ -180,9 +180,9 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
 
             # To restart an interrupted download, read from the offset of last byte
             # received using a range request, and set object generation query param.
-            if self.bytes_downloaded > 0:
+            if self._bytes_downloaded > 0:
                 _download.add_bytes_range(
-                    self.bytes_downloaded, self.end, self._headers
+                    self._bytes_downloaded, self.end, self._headers
                 )
                 request_kwargs["headers"] = self._headers
 
@@ -207,7 +207,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
 
             # With decompressive transcoding, GCS serves back the whole file regardless of the range request,
             # thus we reset the stream position to the start of the stream.
-            # See more: https://cloud.google.com/storage/docs/transcoding#range,
+            # See: https://cloud.google.com/storage/docs/transcoding#range
             if self._stream is not None:
                 if _helpers._is_decompressive_transcoding(result, self._get_headers):
                     self._stream.seek(0)
@@ -267,13 +267,22 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             ~google.resumable_media.common.DataCorruption: If the download's
                 checksum doesn't agree with server-computed checksum.
         """
-
-        # `_get_expected_checksum()` may return None even if a checksum was
-        # requested, in which case it will emit an info log _MISSING_CHECKSUM.
-        # If an invalid checksum type is specified, this will raise ValueError.
-        expected_checksum, checksum_object = _helpers._get_expected_checksum(
-            response, self._get_headers, self.media_url, checksum_type=self.checksum
-        )
+        # Retrieve the expected checksum only once for the download request,
+        # then compute and validate the checksum when the full download completes.
+        # Retried requests are range requests, and there's no way to detect
+        # data corruption for that byte range alone.
+        if self._expected_checksum is None and self._checksum_object is None:
+            # `_get_expected_checksum()` may return None even if a checksum was
+            # requested, in which case it will emit an info log _MISSING_CHECKSUM.
+            # If an invalid checksum type is specified, this will raise ValueError.
+            expected_checksum, checksum_object = _helpers._get_expected_checksum(
+                response, self._get_headers, self.media_url, checksum_type=self.checksum
+            )
+            self._expected_checksum = expected_checksum
+            self._checksum_object = checksum_object
+        else:
+            expected_checksum = self._expected_checksum
+            checksum_object = self._checksum_object
 
         with response:
             body_iter = response.raw.stream(
@@ -281,6 +290,7 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             )
             for chunk in body_iter:
                 self._stream.write(chunk)
+                self._bytes_downloaded += len(chunk)
                 checksum_object.update(chunk)
             response._content_consumed = True
 
@@ -329,23 +339,55 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             ValueError: If the current :class:`Download` has already
                 finished.
         """
-        method, url, payload, headers = self._prepare_request()
+        method, _, payload, headers = self._prepare_request()
+        # NOTE: We assume "payload is None" but pass it along anyway.
+        request_kwargs = {
+            "data": payload,
+            "headers": headers,
+            "timeout": timeout,
+            "stream": True,
+        }
+
+        # Assign object generation if generation is specified in the media url.
+        self._object_generation = _helpers._get_generation_from_url(self.media_url)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
-            # NOTE: We assume "payload is None" but pass it along anyway.
-            result = transport.request(
-                method,
-                url,
-                data=payload,
-                headers=headers,
-                stream=True,
-                timeout=timeout,
-            )
+            url = self.media_url
+
+            # To restart an interrupted download, read from the offset of last byte
+            # received using a range request, and set object generation query param.
+            if self._bytes_downloaded > 0:
+                _download.add_bytes_range(
+                    self._bytes_downloaded, self.end, self._headers
+                )
+                request_kwargs["headers"] = self._headers
+
+                # Set object generation query param to ensure the same object content is requested.
+                if (
+                    self._object_generation is not None
+                    and _helpers._get_generation_from_url(self.media_url) is None
+                ):
+                    query_param = [("generation", self._object_generation)]
+                    url = _helpers.add_query_parameters(self.media_url, query_param)
+
+            result = transport.request(method, url, **request_kwargs)
+
+            # If a generation hasn't been specified, and this is the first response we get, let's record the
+            # generation. In future requests we'll specify the generation query param to avoid data races.
+            if self._object_generation is None:
+                self._object_generation = _helpers._parse_generation_header(
+                    result, self._get_headers
+                )
 
             self._process_response(result)
 
+            # With decompressive transcoding, GCS serves back the whole file regardless of the range request,
+            # thus we reset the stream position to the start of the stream.
+            # See: https://cloud.google.com/storage/docs/transcoding#range
             if self._stream is not None:
+                if _helpers._is_decompressive_transcoding(result, self._get_headers):
+                    self._stream.seek(0)
                 self._write_to_stream(result)
 
             return result

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -161,7 +161,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             ValueError: If the current :class:`Download` has already
                 finished.
         """
-        method, url, payload, headers = self._prepare_request()
+        method, _, payload, headers = self._prepare_request()
         # NOTE: We assume "payload is None" but pass it along anyway.
         request_kwargs = {
             "data": payload,
@@ -172,10 +172,12 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             request_kwargs["stream"] = True
 
         # Assign object generation if generation is specified in the media url
-        self._object_generation = _download.generation_in_media_url(url)
+        self._object_generation = _download.generation_in_media_url(self.media_url)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
+            url = self.media_url
+
             # To restart an interrupted download, read from the offset of last byte
             # received using a range request, and set object generation query param.
             if self.bytes_downloaded > 0:

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -192,7 +192,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
                     self._object_generation is not None
                     and _helpers._get_generation_from_url(self.media_url) is None
                 ):
-                    query_param = [("generation", self._object_generation)]
+                    query_param = {"generation": self._object_generation}
                     url = _helpers.add_query_parameters(self.media_url, query_param)
 
             result = transport.request(method, url, **request_kwargs)
@@ -371,7 +371,7 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
                     self._object_generation is not None
                     and _helpers._get_generation_from_url(self.media_url) is None
                 ):
-                    query_param = [("generation", self._object_generation)]
+                    query_param = {"generation": self._object_generation}
                     url = _helpers.add_query_parameters(self.media_url, query_param)
 
             result = transport.request(method, url, **request_kwargs)

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -36,16 +36,6 @@ but the actual {checksum_type} checksum of the downloaded contents was:
   {}
 """
 
-_STREAM_SEEK_ERROR = """\
-Incomplete download for:
-
-{}
-
-Error writing to stream while handling a gzip-compressed file download.
-
-Please restart the download.
-"""
-
 
 class Download(_request_helpers.RequestsMixin, _download.Download):
     """Helper to manage downloading a resource from a Google API.
@@ -216,17 +206,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
 
             self._process_response(result)
 
-            # With decompressive transcoding, GCS serves back the whole file regardless of the range request,
-            # thus we reset the stream position to the start of the stream.
-            # See: https://cloud.google.com/storage/docs/transcoding#range
             if self._stream is not None:
-                if _helpers._is_decompressive_transcoding(result, self._get_headers):
-                    try:
-                        self._stream.seek(0)
-                    except Exception as exc:
-                        msg = _STREAM_SEEK_ERROR.format(url)
-                        raise Exception(msg) from exc
-                    self._bytes_downloaded = 0
                 self._write_to_stream(result)
 
             return result
@@ -399,17 +379,7 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
 
             self._process_response(result)
 
-            # With decompressive transcoding, GCS serves back the whole file regardless of the range request,
-            # thus we reset the stream position to the start of the stream.
-            # See: https://cloud.google.com/storage/docs/transcoding#range
             if self._stream is not None:
-                if _helpers._is_decompressive_transcoding(result, self._get_headers):
-                    try:
-                        self._stream.seek(0)
-                    except Exception as exc:
-                        msg = _STREAM_SEEK_ERROR.format(url)
-                        raise Exception(msg) from exc
-                    self._bytes_downloaded = 0
                 self._write_to_stream(result)
 
             return result

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -172,7 +172,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             request_kwargs["stream"] = True
 
         # Assign object generation if generation is specified in the media url
-        self._object_generation = _download.generation_in_media_url(self.media_url)
+        self._object_generation = _helpers._get_generation_from_url(self.media_url)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -189,10 +189,10 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
                 # Set object generation query param to ensure the same object content is requested.
                 if (
                     self._object_generation is not None
-                    and _download.generation_in_media_url(self.media_url) is None
+                    and _helpers._get_generation_from_url(self.media_url) is None
                 ):
                     query_param = [("generation", self._object_generation)]
-                    url = _download.add_query_parameters(self.media_url, query_param)
+                    url = _helpers.add_query_parameters(self.media_url, query_param)
 
             result = transport.request(method, url, **request_kwargs)
 

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -172,7 +172,8 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             request_kwargs["stream"] = True
 
         # Assign object generation if generation is specified in the media url.
-        self._object_generation = _helpers._get_generation_from_url(self.media_url)
+        if self._object_generation is None:
+            self._object_generation = _helpers._get_generation_from_url(self.media_url)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -211,6 +212,7 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
             if self._stream is not None:
                 if _helpers._is_decompressive_transcoding(result, self._get_headers):
                     self._stream.seek(0)
+                    self._bytes_downloaded = 0
                 self._write_to_stream(result)
 
             return result
@@ -349,7 +351,8 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
         }
 
         # Assign object generation if generation is specified in the media url.
-        self._object_generation = _helpers._get_generation_from_url(self.media_url)
+        if self._object_generation is None:
+            self._object_generation = _helpers._get_generation_from_url(self.media_url)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -388,6 +391,7 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
             if self._stream is not None:
                 if _helpers._is_decompressive_transcoding(result, self._get_headers):
                     self._stream.seek(0)
+                    self._bytes_downloaded = 0
                 self._write_to_stream(result)
 
             return result

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -171,11 +171,8 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
         if self._stream is not None:
             request_kwargs["stream"] = True
 
-        # Check if object generation is specified in the media_url request
-        # to delete: call helper_method and assign self._object_generation
-        generation_from_url = _download.query_param_in_media_url(url, "generation")
-        if generation_from_url:
-            self._object_generation = int(generation_from_url)
+        # Assign object generation if generation is specified in the media url
+        self._object_generation = _download.generation_in_media_url(url)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -185,23 +182,20 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
                 _download.add_bytes_range(self.bytes_downloaded, self.end, self._headers)
                 request_kwargs["headers"] = self._headers
 
-                # Set object generation query param to ensure the same object content is requested
-                if self._object_generation and not generation_from_url:
-                    # do something: call helper method to generate new url
+                # Set object generation query param to ensure the same object content is requested.
+                if (
+                    self._object_generation is not None
+                    and _download.generation_in_media_url(self.media_url) is None
+                ):
                     query_param = [("generation", self._object_generation)]
-                    base_url = url
-                    url = _download.add_query_parameters(base_url, query_param)
-                # if self._object_generation is not None:
-                #     generation_query = "&generation={}".format(self._object_generation)
-                #     url += generation_query
+                    url = _download.add_query_parameters(self.media_url, query_param)
 
             result = transport.request(method, url, **request_kwargs)
 
             # If a generation hasn't been specified, and this is the first response we get, let's record the
-            # generation. In future requests we'll use this generation as a precondition to avoid data races.
+            # generation. In future requests we'll specify the generation query param to avoid data races.
             if self._object_generation is None:
                 self._object_generation = _helpers._parse_generation_header(result, self._get_headers)
-            # import pdb; pdb.set_trace()
 
             self._process_response(result)
 

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -42,6 +42,7 @@ class TestDownload(object):
         assert ret_val is None
 
         assert stream.getvalue() == chunk1 + chunk2
+        assert download._bytes_downloaded == len(chunk1 + chunk2)
 
         # Check mocks.
         response.__enter__.assert_called_once_with()
@@ -66,6 +67,8 @@ class TestDownload(object):
         assert ret_val is None
 
         assert stream.getvalue() == chunk1 + chunk2 + chunk3
+        assert download._bytes_downloaded == len(chunk1 + chunk2 + chunk3)
+        assert download._checksum_object is not None
 
         # Check mocks.
         response.__enter__.assert_called_once_with()
@@ -273,6 +276,64 @@ class TestDownload(object):
         # Make sure the headers have been modified.
         assert headers == {"range": range_bytes}
 
+    def test_consume_gets_generation_from_url(self):
+        GENERATION_VALUE = 1641590104888641
+        url = EXAMPLE_URL + f"&generation={GENERATION_VALUE}"
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+
+        download = download_mod.Download(
+            url, stream=stream, end=65536, headers=None, checksum="md5"
+        )
+        transport = mock.Mock(spec=["request"])
+        transport.request.return_value = _mock_response(chunks=chunks, headers=None)
+
+        assert not download.finished
+        assert download._object_generation is None
+
+        ret_val = download.consume(transport)
+
+        assert download._object_generation == GENERATION_VALUE
+        assert ret_val is transport.request.return_value
+        assert stream.getvalue() == b"".join(chunks)
+
+        called_kwargs = {
+            "data": None,
+            "headers": download._headers,
+            "timeout": EXPECTED_TIMEOUT,
+            "stream": True,
+        }
+        transport.request.assert_called_once_with("GET", url, **called_kwargs)
+
+    def test_consume_gets_generation_from_headers(self):
+        GENERATION_VALUE = 1641590104888641
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+
+        download = download_mod.Download(
+            EXAMPLE_URL, stream=stream, end=65536, headers=None, checksum="md5"
+        )
+        transport = mock.Mock(spec=["request"])
+        headers = {_helpers._GENERATION_HEADER: GENERATION_VALUE}
+        transport.request.return_value = _mock_response(chunks=chunks, headers=headers)
+
+        assert not download.finished
+        assert download._object_generation is None
+
+        ret_val = download.consume(transport)
+
+        assert download._object_generation == GENERATION_VALUE
+        assert ret_val is transport.request.return_value
+        assert stream.getvalue() == b"".join(chunks)
+
+        called_kwargs = {
+            "data": None,
+            "headers": download._headers,
+            "timeout": EXPECTED_TIMEOUT,
+            "stream": True,
+        }
+        transport.request.assert_called_once_with("GET", EXAMPLE_URL, **called_kwargs)
+
 
 class TestRawDownload(object):
     def test__write_to_stream_no_hash_check(self):
@@ -287,6 +348,7 @@ class TestRawDownload(object):
         assert ret_val is None
 
         assert stream.getvalue() == chunk1 + chunk2
+        assert download._bytes_downloaded == len(chunk1 + chunk2)
 
         # Check mocks.
         response.__enter__.assert_called_once_with()
@@ -313,6 +375,8 @@ class TestRawDownload(object):
         assert ret_val is None
 
         assert stream.getvalue() == chunk1 + chunk2 + chunk3
+        assert download._bytes_downloaded == len(chunk1 + chunk2 + chunk3)
+        assert download._checksum_object is not None
 
         # Check mocks.
         response.__enter__.assert_called_once_with()
@@ -525,6 +589,66 @@ class TestRawDownload(object):
         range_bytes = "bytes={:d}-{:d}".format(0, end)
         # Make sure the headers have been modified.
         assert headers == {"range": range_bytes}
+
+    def test_consume_gets_generation_from_url(self):
+        GENERATION_VALUE = 1641590104888641
+        url = EXAMPLE_URL + f"&generation={GENERATION_VALUE}"
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+
+        download = download_mod.RawDownload(
+            url, stream=stream, end=65536, headers=None, checksum="md5"
+        )
+        transport = mock.Mock(spec=["request"])
+        transport.request.return_value = _mock_raw_response(chunks=chunks, headers=None)
+
+        assert not download.finished
+        assert download._object_generation is None
+
+        ret_val = download.consume(transport)
+
+        assert download._object_generation == GENERATION_VALUE
+        assert ret_val is transport.request.return_value
+        assert stream.getvalue() == b"".join(chunks)
+
+        called_kwargs = {
+            "data": None,
+            "headers": download._headers,
+            "timeout": EXPECTED_TIMEOUT,
+            "stream": True,
+        }
+        transport.request.assert_called_once_with("GET", url, **called_kwargs)
+
+    def test_consume_gets_generation_from_headers(self):
+        GENERATION_VALUE = 1641590104888641
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+
+        download = download_mod.RawDownload(
+            EXAMPLE_URL, stream=stream, end=65536, headers=None, checksum="md5"
+        )
+        transport = mock.Mock(spec=["request"])
+        headers = {_helpers._GENERATION_HEADER: GENERATION_VALUE}
+        transport.request.return_value = _mock_raw_response(
+            chunks=chunks, headers=headers
+        )
+
+        assert not download.finished
+        assert download._object_generation is None
+
+        ret_val = download.consume(transport)
+
+        assert download._object_generation == GENERATION_VALUE
+        assert ret_val is transport.request.return_value
+        assert stream.getvalue() == b"".join(chunks)
+
+        called_kwargs = {
+            "data": None,
+            "headers": download._headers,
+            "timeout": EXPECTED_TIMEOUT,
+            "stream": True,
+        }
+        transport.request.assert_called_once_with("GET", EXAMPLE_URL, **called_kwargs)
 
 
 class TestChunkedDownload(object):

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -395,45 +395,6 @@ class TestDownload(object):
         range_bytes = "bytes={:d}-{:d}".format(offset, end)
         assert download._headers["range"] == range_bytes
 
-    def test_consume_gzip_reset_stream_w_bytes_downloaded(self):
-        stream = io.BytesIO()
-        chunks = (b"up down ", b"charlie ", b"brown")
-        end = 65536
-
-        download = download_mod.Download(
-            EXAMPLE_URL, stream=stream, end=end, headers=None, checksum="md5"
-        )
-        transport = mock.Mock(spec=["request"])
-
-        # Mock a decompressive transcoding retry operation with bytes already downloaded in the stream
-        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
-        transport.request.return_value = _mock_response(chunks=chunks, headers=headers)
-        offset = 16
-        download._bytes_downloaded = offset
-        download.consume(transport)
-
-        assert stream.getvalue() == b"".join(chunks)
-        assert download._bytes_downloaded == len(b"".join(chunks))
-
-    def test_consume_gzip_reset_stream_error(self):
-        stream = io.BytesIO()
-        chunks = (b"up down ", b"charlie ", b"brown")
-        end = 65536
-
-        download = download_mod.Download(
-            EXAMPLE_URL, stream=stream, end=end, headers=None, checksum="md5"
-        )
-        transport = mock.Mock(spec=["request"])
-
-        # Mock a stream seek error while resuming a decompressive transcoding download
-        stream.seek = mock.Mock(side_effect=OSError("mock stream seek error"))
-        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
-        transport.request.return_value = _mock_response(chunks=chunks, headers=headers)
-        offset = 16
-        download._bytes_downloaded = offset
-        with pytest.raises(Exception):
-            download.consume(transport)
-
 
 class TestRawDownload(object):
     def test__write_to_stream_no_hash_check(self):
@@ -810,49 +771,6 @@ class TestRawDownload(object):
         transport.request.assert_called_once_with("GET", EXAMPLE_URL, **called_kwargs)
         range_bytes = "bytes={:d}-{:d}".format(offset, end)
         assert download._headers["range"] == range_bytes
-
-    def test_consume_gzip_reset_stream_w_bytes_downloaded(self):
-        stream = io.BytesIO()
-        chunks = (b"up down ", b"charlie ", b"brown")
-        end = 65536
-
-        download = download_mod.RawDownload(
-            EXAMPLE_URL, stream=stream, end=end, headers=None, checksum="md5"
-        )
-        transport = mock.Mock(spec=["request"])
-
-        # Mock a decompressive transcoding retry operation with bytes already downloaded in the stream
-        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
-        transport.request.return_value = _mock_raw_response(
-            chunks=chunks, headers=headers
-        )
-        offset = 16
-        download._bytes_downloaded = offset
-        download.consume(transport)
-
-        assert stream.getvalue() == b"".join(chunks)
-        assert download._bytes_downloaded == len(b"".join(chunks))
-
-    def test_consume_gzip_reset_stream_error(self):
-        stream = io.BytesIO()
-        chunks = (b"up down ", b"charlie ", b"brown")
-        end = 65536
-
-        download = download_mod.RawDownload(
-            EXAMPLE_URL, stream=stream, end=end, headers=None, checksum="md5"
-        )
-        transport = mock.Mock(spec=["request"])
-
-        # Mock a stream seek error while resuming a decompressive transcoding download
-        stream.seek = mock.Mock(side_effect=OSError("mock stream seek error"))
-        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
-        transport.request.return_value = _mock_raw_response(
-            chunks=chunks, headers=headers
-        )
-        offset = 16
-        download._bytes_downloaded = offset
-        with pytest.raises(Exception):
-            download.consume(transport)
 
 
 class TestChunkedDownload(object):

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -415,6 +415,25 @@ class TestDownload(object):
         assert stream.getvalue() == b"".join(chunks)
         assert download._bytes_downloaded == len(b"".join(chunks))
 
+    def test_consume_gzip_reset_stream_error(self):
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+        end = 65536
+
+        download = download_mod.Download(
+            EXAMPLE_URL, stream=stream, end=end, headers=None, checksum="md5"
+        )
+        transport = mock.Mock(spec=["request"])
+
+        # Mock a stream seek error while resuming a decompressive transcoding download
+        stream.seek = mock.Mock(side_effect=OSError("mock stream seek error"))
+        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
+        transport.request.return_value = _mock_response(chunks=chunks, headers=headers)
+        offset = 16
+        download._bytes_downloaded = offset
+        with pytest.raises(Exception):
+            download.consume(transport)
+
 
 class TestRawDownload(object):
     def test__write_to_stream_no_hash_check(self):
@@ -792,7 +811,7 @@ class TestRawDownload(object):
         range_bytes = "bytes={:d}-{:d}".format(offset, end)
         assert download._headers["range"] == range_bytes
 
-    def test_consume_gzip__reset_stream_w_bytes_downloaded(self):
+    def test_consume_gzip_reset_stream_w_bytes_downloaded(self):
         stream = io.BytesIO()
         chunks = (b"up down ", b"charlie ", b"brown")
         end = 65536
@@ -813,6 +832,27 @@ class TestRawDownload(object):
 
         assert stream.getvalue() == b"".join(chunks)
         assert download._bytes_downloaded == len(b"".join(chunks))
+
+    def test_consume_gzip_reset_stream_error(self):
+        stream = io.BytesIO()
+        chunks = (b"up down ", b"charlie ", b"brown")
+        end = 65536
+
+        download = download_mod.RawDownload(
+            EXAMPLE_URL, stream=stream, end=end, headers=None, checksum="md5"
+        )
+        transport = mock.Mock(spec=["request"])
+
+        # Mock a stream seek error while resuming a decompressive transcoding download
+        stream.seek = mock.Mock(side_effect=OSError("mock stream seek error"))
+        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
+        transport.request.return_value = _mock_raw_response(
+            chunks=chunks, headers=headers
+        )
+        offset = 16
+        download._bytes_downloaded = offset
+        with pytest.raises(Exception):
+            download.consume(transport)
 
 
 class TestChunkedDownload(object):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -408,6 +408,83 @@ class Test__parse_checksum_header(object):
         assert error.args[2] == [self.MD5_CHECKSUM, another_checksum]
 
 
+class Test__parse_generation_header(object):
+
+    GENERATION_VALUE = 1641590104888641
+
+    def test_empty_value(self):
+        headers = {}
+        response = _mock_response(headers=headers)
+        generation_header = _helpers._parse_generation_header(response, _get_headers)
+        assert generation_header is None
+
+    def test_header_value(self):
+        headers = {_helpers._GENERATION_HEADER: self.GENERATION_VALUE}
+        response = _mock_response(headers=headers)
+        generation_header = _helpers._parse_generation_header(response, _get_headers)
+        assert generation_header == self.GENERATION_VALUE
+
+
+class Test__is_decompressive_transcoding(object):
+    def test_empty_value(self):
+        headers = {}
+        response = _mock_response(headers=headers)
+        assert _helpers._is_decompressive_transcoding(response, _get_headers) is False
+
+    def test_gzip_in_header(self):
+        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
+        response = _mock_response(headers=headers)
+        assert _helpers._is_decompressive_transcoding(response, _get_headers) is True
+
+    def test_gzip_not_in_header(self):
+        headers = {_helpers._CONTENT_ENCODING_HEADER: "br"}
+        response = _mock_response(headers=headers)
+        assert _helpers._is_decompressive_transcoding(response, _get_headers) is False
+
+
+class Test__get_generation_from_url(object):
+
+    GENERATION_VALUE = 1641590104888641
+    MEDIA_URL = (
+        "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object?alt=media"
+    )
+    MEDIA_URL_W_GENERATION = MEDIA_URL + f"&generation={GENERATION_VALUE}"
+
+    def test_empty_value(self):
+        generation = _helpers._get_generation_from_url(self.MEDIA_URL)
+        assert generation is None
+
+    def test_generation_in_url(self):
+        generation = _helpers._get_generation_from_url(self.MEDIA_URL_W_GENERATION)
+        assert generation == self.GENERATION_VALUE
+
+
+class Test__add_query_parameters(object):
+    def test_w_empty_list(self):
+        query_params = []
+        MEDIA_URL = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object"
+        new_url = _helpers.add_query_parameters(MEDIA_URL, query_params)
+        assert new_url == MEDIA_URL
+
+    def test_wo_existing_qs(self):
+        query_params = [("one", "One"), ("two", "Two")]
+        MEDIA_URL = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object"
+        expected = "&".join(
+            ["{}={}".format(name, value) for name, value in query_params]
+        )
+        new_url = _helpers.add_query_parameters(MEDIA_URL, query_params)
+        assert new_url == "{}?{}".format(MEDIA_URL, expected)
+
+    def test_w_existing_qs(self):
+        query_params = [("one", "One"), ("two", "Two")]
+        MEDIA_URL = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object?alt=media"
+        expected = "&".join(
+            ["{}={}".format(name, value) for name, value in query_params]
+        )
+        new_url = _helpers.add_query_parameters(MEDIA_URL, query_params)
+        assert new_url == "{}&{}".format(MEDIA_URL, expected)
+
+
 def _mock_response(headers):
     return mock.Mock(
         headers=headers,

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -461,25 +461,25 @@ class Test__get_generation_from_url(object):
 
 class Test__add_query_parameters(object):
     def test_w_empty_list(self):
-        query_params = []
+        query_params = {}
         MEDIA_URL = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object"
         new_url = _helpers.add_query_parameters(MEDIA_URL, query_params)
         assert new_url == MEDIA_URL
 
     def test_wo_existing_qs(self):
-        query_params = [("one", "One"), ("two", "Two")]
+        query_params = {"one": "One", "two": "Two"}
         MEDIA_URL = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object"
         expected = "&".join(
-            ["{}={}".format(name, value) for name, value in query_params]
+            ["{}={}".format(name, value) for name, value in query_params.items()]
         )
         new_url = _helpers.add_query_parameters(MEDIA_URL, query_params)
         assert new_url == "{}?{}".format(MEDIA_URL, expected)
 
     def test_w_existing_qs(self):
-        query_params = [("one", "One"), ("two", "Two")]
+        query_params = {"one": "One", "two": "Two"}
         MEDIA_URL = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/my-object?alt=media"
         expected = "&".join(
-            ["{}={}".format(name, value) for name, value in query_params]
+            ["{}={}".format(name, value) for name, value in query_params.items()]
         )
         new_url = _helpers.add_query_parameters(MEDIA_URL, query_params)
         assert new_url == "{}&{}".format(MEDIA_URL, expected)

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -425,23 +425,6 @@ class Test__parse_generation_header(object):
         assert generation_header == self.GENERATION_VALUE
 
 
-class Test__is_decompressive_transcoding(object):
-    def test_empty_value(self):
-        headers = {}
-        response = _mock_response(headers=headers)
-        assert _helpers._is_decompressive_transcoding(response, _get_headers) is False
-
-    def test_gzip_in_header(self):
-        headers = {_helpers._CONTENT_ENCODING_HEADER: "gzip"}
-        response = _mock_response(headers=headers)
-        assert _helpers._is_decompressive_transcoding(response, _get_headers) is True
-
-    def test_gzip_not_in_header(self):
-        headers = {_helpers._CONTENT_ENCODING_HEADER: "br"}
-        response = _mock_response(headers=headers)
-        assert _helpers._is_decompressive_transcoding(response, _get_headers) is False
-
-
 class Test__get_generation_from_url(object):
 
     GENERATION_VALUE = 1641590104888641


### PR DESCRIPTION
If a retryable error occurs mid-download, the download starts sending data to the stream from the `offset_of_last_byte_received` rather than starting from the beginning of the file, and resolves data integrity issues. 

- for interruped downloads, safely resume by reading from offset_of_last_byte_received using a ranged get request and include object generation URL query parameter to make sure the same object content is requested
- adds support for download instances to track information such as `object_generation` and `bytes downloaded`
- adds tests

Fixes #284 