### PR TITLE
fix: don't overwrite user-agent on requests

### DIFF
--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -58,7 +58,7 @@ class DownloadBase(object):
         self.end = end
         if headers is None:
             headers = {}
-        self._headers = _helpers._base_headers(headers)
+        self._headers = headers
         self._finished = False
         self._retry_strategy = common.RetryStrategy()
 

--- a/google/resumable_media/_helpers.py
+++ b/google/resumable_media/_helpers.py
@@ -20,7 +20,6 @@ import base64
 import hashlib
 import logging
 import random
-import pkg_resources
 import warnings
 
 from google.resumable_media import common
@@ -44,13 +43,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def do_nothing():
     """Simple default callback."""
-
-
-def _base_headers(headers):
-    version = pkg_resources.get_distribution("google-resumable-media").version
-    headers["User-Agent"] = "gcloud-python/{}-resumable-media".format(version)
-    headers["X-Goog-Api-Client"] = "gcloud-python/{}-resumable-media".format(version)
-    return headers
 
 
 def header_required(response, name, get_headers, callback=do_nothing):

--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -83,7 +83,7 @@ class UploadBase(object):
         self.upload_url = upload_url
         if headers is None:
             headers = {}
-        self._headers = _helpers._base_headers(headers)
+        self._headers = headers
         self._finished = False
         self._retry_strategy = common.RetryStrategy()
 

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -22,7 +22,7 @@ from google.resumable_media import common
 from google.resumable_media import _helpers
 from google.resumable_media.requests import download as download_mod
 from google.resumable_media.requests import _request_helpers
-from google.resumable_media._helpers import _base_headers
+
 
 URL_PREFIX = "https://www.googleapis.com/download/storage/v1/b/{BUCKET}/o/"
 EXAMPLE_URL = URL_PREFIX + "{OBJECT}?alt=media"
@@ -241,7 +241,7 @@ class TestDownload(object):
 
         assert stream.getvalue() == b"".join(chunks)
         assert download.finished
-        assert download._headers == _base_headers({})
+        assert download._headers == {}
 
         error = exc_info.value
         assert error.response is transport.request.return_value
@@ -260,7 +260,7 @@ class TestDownload(object):
             "GET",
             EXAMPLE_URL,
             data=None,
-            headers=_base_headers({}),
+            headers={},
             stream=True,
             timeout=EXPECTED_TIMEOUT,
         )
@@ -271,7 +271,7 @@ class TestDownload(object):
         self._consume_helper(end=end, headers=headers)
         range_bytes = "bytes={:d}-{:d}".format(0, end)
         # Make sure the headers have been modified.
-        assert headers == _base_headers({"range": range_bytes})
+        assert headers == {"range": range_bytes}
 
 
 class TestRawDownload(object):
@@ -494,7 +494,7 @@ class TestRawDownload(object):
 
         assert stream.getvalue() == b"".join(chunks)
         assert download.finished
-        assert download._headers == _base_headers({})
+        assert download._headers == {}
 
         error = exc_info.value
         assert error.response is transport.request.return_value
@@ -513,7 +513,7 @@ class TestRawDownload(object):
             "GET",
             EXAMPLE_URL,
             data=None,
-            headers=_base_headers({}),
+            headers={},
             stream=True,
             timeout=EXPECTED_TIMEOUT,
         )
@@ -524,7 +524,7 @@ class TestRawDownload(object):
         self._consume_helper(end=end, headers=headers)
         range_bytes = "bytes={:d}-{:d}".format(0, end)
         # Make sure the headers have been modified.
-        assert headers == _base_headers({"range": range_bytes})
+        assert headers == {"range": range_bytes}
 
 
 class TestChunkedDownload(object):
@@ -589,7 +589,7 @@ class TestChunkedDownload(object):
         ret_val = download.consume_next_chunk(transport)
         assert ret_val is transport.request.return_value
         range_bytes = "bytes={:d}-{:d}".format(start, start + chunk_size - 1)
-        download_headers = _base_headers({"range": range_bytes})
+        download_headers = {"range": range_bytes}
         transport.request.assert_called_once_with(
             "GET",
             EXAMPLE_URL,
@@ -618,7 +618,7 @@ class TestChunkedDownload(object):
         download.consume_next_chunk(transport, timeout=14.7)
 
         range_bytes = "bytes={:d}-{:d}".format(start, start + chunk_size - 1)
-        download_headers = _base_headers({"range": range_bytes})
+        download_headers = {"range": range_bytes}
         transport.request.assert_called_once_with(
             "GET",
             EXAMPLE_URL,
@@ -695,7 +695,7 @@ class TestRawChunkedDownload(object):
             "GET",
             EXAMPLE_URL,
             data=None,
-            headers=_base_headers(download_headers),
+            headers=download_headers,
             stream=True,
             timeout=EXPECTED_TIMEOUT,
         )
@@ -725,7 +725,7 @@ class TestRawChunkedDownload(object):
             "GET",
             EXAMPLE_URL,
             data=None,
-            headers=_base_headers(download_headers),
+            headers=download_headers,
             stream=True,
             timeout=14.7,
         )

--- a/tests/unit/requests/test_upload.py
+++ b/tests/unit/requests/test_upload.py
@@ -19,7 +19,6 @@ import json
 import mock
 
 import google.resumable_media.requests.upload as upload_mod
-from google.resumable_media._helpers import _base_headers
 
 
 URL_PREFIX = "https://www.googleapis.com/upload/storage/v1/b/{BUCKET}/o"
@@ -49,7 +48,7 @@ class TestSimpleUpload(object):
             "POST",
             SIMPLE_URL,
             data=data,
-            headers=_base_headers(upload_headers),
+            headers=upload_headers,
             timeout=EXPECTED_TIMEOUT,
         )
         assert upload.finished
@@ -68,7 +67,7 @@ class TestSimpleUpload(object):
             "POST",
             SIMPLE_URL,
             data=data,
-            headers=_base_headers(expected_headers),
+            headers=expected_headers,
             timeout=12.6,
         )
 
@@ -104,7 +103,7 @@ class TestMultipartUpload(object):
             "POST",
             MULTIPART_URL,
             data=expected_payload,
-            headers=_base_headers(upload_headers),
+            headers=upload_headers,
             timeout=EXPECTED_TIMEOUT,
         )
         assert upload.finished
@@ -142,7 +141,7 @@ class TestMultipartUpload(object):
             "POST",
             MULTIPART_URL,
             data=expected_payload,
-            headers=_base_headers(upload_headers),
+            headers=upload_headers,
             timeout=12.6,
         )
         assert upload.finished
@@ -188,7 +187,7 @@ class TestResumableUpload(object):
             "POST",
             RESUMABLE_URL,
             data=json_bytes,
-            headers=_base_headers(expected_headers),
+            headers=expected_headers,
             timeout=EXPECTED_TIMEOUT,
         )
 
@@ -224,7 +223,7 @@ class TestResumableUpload(object):
             "POST",
             RESUMABLE_URL,
             data=json_bytes,
-            headers=_base_headers(expected_headers),
+            headers=expected_headers,
             timeout=12.6,
         )
 

--- a/tests/unit/test__download.py
+++ b/tests/unit/test__download.py
@@ -20,7 +20,7 @@ import pytest  # type: ignore
 
 from google.resumable_media import _download
 from google.resumable_media import common
-from google.resumable_media._helpers import _base_headers
+
 
 EXAMPLE_URL = (
     "https://www.googleapis.com/download/storage/v1/b/{BUCKET}/o/{OBJECT}?alt=media"
@@ -34,7 +34,7 @@ class TestDownloadBase(object):
         assert download._stream is None
         assert download.start is None
         assert download.end is None
-        assert download._headers == _base_headers({})
+        assert download._headers == {}
         assert not download._finished
         _check_retry_strategy(download)
 
@@ -53,7 +53,7 @@ class TestDownloadBase(object):
         assert download._stream is mock.sentinel.stream
         assert download.start == start
         assert download.end == end
-        assert download._headers == _base_headers(headers)
+        assert download._headers is headers
         assert not download._finished
         _check_retry_strategy(download)
 
@@ -102,14 +102,14 @@ class TestDownload(object):
         assert method1 == "GET"
         assert url1 == EXAMPLE_URL
         assert payload1 is None
-        assert headers1 == _base_headers({})
+        assert headers1 == {}
 
         download2 = _download.Download(EXAMPLE_URL, start=53)
         method2, url2, payload2, headers2 = download2._prepare_request()
         assert method2 == "GET"
         assert url2 == EXAMPLE_URL
         assert payload2 is None
-        assert headers2 == _base_headers({"range": "bytes=53-"})
+        assert headers2 == {"range": "bytes=53-"}
 
     def test__prepare_request_with_headers(self):
         headers = {"spoonge": "borb"}
@@ -118,9 +118,8 @@ class TestDownload(object):
         assert method == "GET"
         assert url == EXAMPLE_URL
         assert payload is None
-        assert new_headers == _base_headers(
-            {"range": "bytes=11-111", "spoonge": "borb"}
-        )
+        assert new_headers is headers
+        assert headers == {"range": "bytes=11-111", "spoonge": "borb"}
 
     def test__process_response(self):
         download = _download.Download(EXAMPLE_URL)
@@ -172,7 +171,7 @@ class TestChunkedDownload(object):
         assert download.chunk_size == chunk_size
         assert download.start == 0
         assert download.end is None
-        assert download._headers == _base_headers({})
+        assert download._headers == {}
         assert not download._finished
         _check_retry_strategy(download)
         assert download._stream is stream
@@ -289,7 +288,7 @@ class TestChunkedDownload(object):
         assert method1 == "GET"
         assert url1 == EXAMPLE_URL
         assert payload1 is None
-        assert headers1 == _base_headers({"range": "bytes=0-2047"})
+        assert headers1 == {"range": "bytes=0-2047"}
 
         download2 = _download.ChunkedDownload(
             EXAMPLE_URL, chunk_size, None, start=19991
@@ -299,7 +298,7 @@ class TestChunkedDownload(object):
         assert method2 == "GET"
         assert url2 == EXAMPLE_URL
         assert payload2 is None
-        assert headers2 == _base_headers({"range": "bytes=19991-20100"})
+        assert headers2 == {"range": "bytes=19991-20100"}
 
     def test__prepare_request_with_headers(self):
         chunk_size = 2048
@@ -311,8 +310,9 @@ class TestChunkedDownload(object):
         assert method == "GET"
         assert url == EXAMPLE_URL
         assert payload is None
+        assert new_headers is headers
         expected = {"patrizio": "Starf-ish", "range": "bytes=0-2047"}
-        assert new_headers == _base_headers(expected)
+        assert headers == expected
 
     def test__make_invalid(self):
         download = _download.ChunkedDownload(EXAMPLE_URL, 512, None)

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -22,7 +22,6 @@ import pytest  # type: ignore
 from google.resumable_media import _helpers
 from google.resumable_media import _upload
 from google.resumable_media import common
-from google.resumable_media._helpers import _base_headers
 
 
 URL_PREFIX = "https://www.googleapis.com/upload/storage/v1/b/{BUCKET}/o"
@@ -39,7 +38,7 @@ class TestUploadBase(object):
     def test_constructor_defaults(self):
         upload = _upload.UploadBase(SIMPLE_URL)
         assert upload.upload_url == SIMPLE_URL
-        assert upload._headers == _base_headers({})
+        assert upload._headers == {}
         assert not upload._finished
         _check_retry_strategy(upload)
 
@@ -47,7 +46,7 @@ class TestUploadBase(object):
         headers = {"spin": "doctors"}
         upload = _upload.UploadBase(SIMPLE_URL, headers=headers)
         assert upload.upload_url == SIMPLE_URL
-        assert upload._headers == _base_headers(headers)
+        assert upload._headers is headers
         assert not upload._finished
         _check_retry_strategy(upload)
 
@@ -140,7 +139,7 @@ class TestSimpleUpload(object):
         assert method == "POST"
         assert url == SIMPLE_URL
         assert payload == data
-        assert headers == _base_headers({"content-type": content_type})
+        assert headers == {"content-type": content_type}
 
     def test__prepare_request_with_headers(self):
         headers = {"x-goog-cheetos": "spicy"}
@@ -152,8 +151,9 @@ class TestSimpleUpload(object):
         assert method == "POST"
         assert url == SIMPLE_URL
         assert payload == data
+        assert new_headers is headers
         expected = {"content-type": content_type, "x-goog-cheetos": "spicy"}
-        assert new_headers == _base_headers(expected)
+        assert headers == expected
 
     def test_transmit(self):
         upload = _upload.SimpleUpload(SIMPLE_URL)
@@ -167,7 +167,7 @@ class TestMultipartUpload(object):
     def test_constructor_defaults(self):
         upload = _upload.MultipartUpload(MULTIPART_URL)
         assert upload.upload_url == MULTIPART_URL
-        assert upload._headers == _base_headers({})
+        assert upload._headers == {}
         assert upload._checksum_type is None
         assert not upload._finished
         _check_retry_strategy(upload)
@@ -176,7 +176,7 @@ class TestMultipartUpload(object):
         headers = {"spin": "doctors"}
         upload = _upload.MultipartUpload(MULTIPART_URL, headers=headers, checksum="md5")
         assert upload.upload_url == MULTIPART_URL
-        assert upload._headers == _base_headers(headers)
+        assert upload._headers is headers
         assert upload._checksum_type == "md5"
         assert not upload._finished
         _check_retry_strategy(upload)
@@ -255,19 +255,18 @@ class TestMultipartUpload(object):
 
     def test__prepare_request(self):
         headers, multipart_type = self._prepare_request_helper()
-        assert headers == _base_headers({"content-type": multipart_type})
+        assert headers == {"content-type": multipart_type}
 
     def test__prepare_request_with_headers(self):
         headers = {"best": "shirt", "worst": "hat"}
         new_headers, multipart_type = self._prepare_request_helper(headers=headers)
-        expected_headers = _base_headers(
-            {
-                "best": "shirt",
-                "content-type": multipart_type,
-                "worst": "hat",
-            }
-        )
-        assert new_headers == expected_headers
+        assert new_headers is headers
+        expected_headers = {
+            "best": "shirt",
+            "content-type": multipart_type,
+            "worst": "hat",
+        }
+        assert expected_headers == headers
 
     @pytest.mark.parametrize("checksum", ["md5", "crc32c"])
     def test__prepare_request_with_checksum(self, checksum):
@@ -278,11 +277,9 @@ class TestMultipartUpload(object):
         headers, multipart_type = self._prepare_request_helper(
             checksum=checksum, expected_checksum=checksums[checksum]
         )
-        assert headers == _base_headers(
-            {
-                "content-type": multipart_type,
-            }
-        )
+        assert headers == {
+            "content-type": multipart_type,
+        }
 
     @pytest.mark.parametrize("checksum", ["md5", "crc32c"])
     def test__prepare_request_with_checksum_overwrite(self, checksum):
@@ -295,11 +292,9 @@ class TestMultipartUpload(object):
             expected_checksum=checksums[checksum],
             test_overwrite=True,
         )
-        assert headers == _base_headers(
-            {
-                "content-type": multipart_type,
-            }
-        )
+        assert headers == {
+            "content-type": multipart_type,
+        }
 
     def test_transmit(self):
         upload = _upload.MultipartUpload(MULTIPART_URL)
@@ -314,7 +309,7 @@ class TestResumableUpload(object):
         chunk_size = ONE_MB
         upload = _upload.ResumableUpload(RESUMABLE_URL, chunk_size)
         assert upload.upload_url == RESUMABLE_URL
-        assert upload._headers == _base_headers({})
+        assert upload._headers == {}
         assert not upload._finished
         _check_retry_strategy(upload)
         assert upload._chunk_size == chunk_size
@@ -440,7 +435,7 @@ class TestResumableUpload(object):
             "x-upload-content-length": "{:d}".format(len(data)),
             "x-upload-content-type": BASIC_CONTENT,
         }
-        assert headers == _base_headers(expected_headers)
+        assert headers == expected_headers
 
     def test_prepare_initiate_request_with_signed_url(self):
         signed_urls = [
@@ -455,7 +450,7 @@ class TestResumableUpload(object):
                 "content-type": BASIC_CONTENT,
                 "x-upload-content-length": "{:d}".format(len(data)),
             }
-            assert headers == _base_headers(expected_headers)
+            assert headers == expected_headers
 
     def test__prepare_initiate_request_with_headers(self):
         headers = {"caviar": "beluga", "top": "quark"}
@@ -469,7 +464,7 @@ class TestResumableUpload(object):
             "x-upload-content-length": "{:d}".format(len(data)),
             "x-upload-content-type": BASIC_CONTENT,
         }
-        assert new_headers == _base_headers(expected_headers)
+        assert new_headers == expected_headers
 
     def test__prepare_initiate_request_known_size(self):
         total_bytes = 25
@@ -480,7 +475,7 @@ class TestResumableUpload(object):
             "x-upload-content-length": "{:d}".format(total_bytes),
             "x-upload-content-type": BASIC_CONTENT,
         }
-        assert headers == _base_headers(expected_headers)
+        assert headers == expected_headers
 
     def test__prepare_initiate_request_unknown_size(self):
         _, headers = self._prepare_initiate_request_helper(stream_final=False)
@@ -488,7 +483,7 @@ class TestResumableUpload(object):
             "content-type": "application/json; charset=UTF-8",
             "x-upload-content-type": BASIC_CONTENT,
         }
-        assert headers == _base_headers(expected_headers)
+        assert headers == expected_headers
 
     def test__prepare_initiate_request_already_initiated(self):
         upload = _upload.ResumableUpload(RESUMABLE_URL, ONE_MB)
@@ -965,7 +960,7 @@ class TestResumableUpload(object):
         assert payload is None
         assert headers == {"content-range": "bytes */*"}
         # Make sure headers are untouched.
-        assert upload._headers == _base_headers({})
+        assert upload._headers == {}
 
     def test__prepare_recover_request_with_headers(self):
         headers = {"lake": "ocean"}
@@ -980,7 +975,7 @@ class TestResumableUpload(object):
         # Make sure the ``_headers`` are not incorporated.
         assert "lake" not in new_headers
         # Make sure headers are untouched.
-        assert upload._headers == _base_headers({"lake": "ocean"})
+        assert upload._headers == {"lake": "ocean"}
 
     def test__process_recover_response_bad_status(self):
         upload = _upload.ResumableUpload(RESUMABLE_URL, ONE_MB)


### PR DESCRIPTION
Reverts googleapis/google-resumable-media-python#295

Closes https://github.com/googleapis/google-resumable-media-python/issues/296

BEGIN_COMMIT_OVERRIDE
fix: don't overwrite user-agent on requests
END_COMMIT_OVERRIDE