### PR TITLE
fix: include existing headers in prepare request

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -619,6 +619,7 @@ class ResumableUpload(UploadBase):
         self._update_checksum(start_byte, payload)
 
         headers = {
+            **self._headers,
             _CONTENT_TYPE_HEADER: self._content_type,
             _helpers.CONTENT_RANGE_HEADER: content_range,
         }

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -617,11 +617,11 @@ class TestResumableUpload(object):
         assert headers == expected_headers
 
     def test__prepare_request_success_with_headers(self):
-        headers = {"cannot": "touch this"}
+        headers = {"keep": "this"}
         new_headers = self._prepare_request_helper(headers)
         assert new_headers is not headers
         expected_headers = {
-            "cannot": "touch this",
+            "keep": "this",
             "content-range": "bytes 0-32/33",
             "content-type": BASIC_CONTENT,
         }

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -621,12 +621,11 @@ class TestResumableUpload(object):
         new_headers = self._prepare_request_helper(headers)
         assert new_headers is not headers
         expected_headers = {
+            "cannot": "touch this",
             "content-range": "bytes 0-32/33",
             "content-type": BASIC_CONTENT,
         }
         assert new_headers == expected_headers
-        # Make sure the ``_headers`` are not incorporated.
-        assert "cannot" not in new_headers
 
     @pytest.mark.parametrize("checksum", ["md5", "crc32c"])
     def test__prepare_request_with_checksum(self, checksum):


### PR DESCRIPTION
This is a needed change to allow us to properly set user agent from the python-storage library, for multi-chunked uploads.