### PR TITLE
fix: append existing headers in prepare_initiate_request

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -468,8 +468,10 @@ class ResumableUpload(UploadBase):
         parse_result = urllib.parse.urlparse(self.upload_url)
         parsed_query = urllib.parse.parse_qs(parse_result.query)
         if "x-goog-signature" in parsed_query or "X-Goog-Signature" in parsed_query:
+            # Deconstruct **self._headers first so that content type defined here takes priority
             headers = {**self._headers, _CONTENT_TYPE_HEADER: content_type}
         else:
+            # Deconstruct **self._headers first so that content type defined here takes priority
             headers = {
                 **self._headers,
                 _CONTENT_TYPE_HEADER: "application/json; charset=UTF-8",

--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -468,9 +468,10 @@ class ResumableUpload(UploadBase):
         parse_result = urllib.parse.urlparse(self.upload_url)
         parsed_query = urllib.parse.parse_qs(parse_result.query)
         if "x-goog-signature" in parsed_query or "X-Goog-Signature" in parsed_query:
-            headers = {_CONTENT_TYPE_HEADER: content_type}
+            headers = {**self._headers, _CONTENT_TYPE_HEADER: content_type}
         else:
             headers = {
+                **self._headers,
                 _CONTENT_TYPE_HEADER: "application/json; charset=UTF-8",
                 "x-upload-content-type": content_type,
             }
@@ -484,7 +485,6 @@ class ResumableUpload(UploadBase):
             content_length = "{:d}".format(self._total_bytes)
             headers["x-upload-content-length"] = content_length
 
-        headers.update(self._headers)
         payload = json.dumps(metadata).encode("utf-8")
         return _POST, self.upload_url, payload, headers
 

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -454,7 +454,11 @@ class TestResumableUpload(object):
 
     def test__prepare_initiate_request_with_headers(self):
         # content-type header should be overwritten, the rest should stay
-        headers = {"caviar": "beluga", "top": "quark", "content-type": "application/xhtml"}
+        headers = {
+            "caviar": "beluga",
+            "top": "quark",
+            "content-type": "application/xhtml",
+        }
         data, new_headers = self._prepare_initiate_request_helper(
             upload_headers=headers
         )

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -453,7 +453,8 @@ class TestResumableUpload(object):
             assert headers == expected_headers
 
     def test__prepare_initiate_request_with_headers(self):
-        headers = {"caviar": "beluga", "top": "quark"}
+        # content-type header should be overwritten, the rest should stay
+        headers = {"caviar": "beluga", "top": "quark", "content-type": "application/xhtml"}
         data, new_headers = self._prepare_initiate_request_helper(
             upload_headers=headers
         )


### PR DESCRIPTION
Big uggghhhhh, but the last change missed a necessary place for headers to be appended and I missed that in the testing. This time, double checked and all things pass, and so this is requiring cutting another quick release but it will allow for that change to come fully through.