### PR TITLE
fix: Use unittest.mock

### DIFF
--- a/tests/system/requests/test_upload.py
+++ b/tests/system/requests/test_upload.py
@@ -20,7 +20,7 @@ import os
 import urllib.parse
 
 import pytest  # type: ignore
-import mock
+from unittest import mock
 
 from google.resumable_media import common
 from google import resumable_media

--- a/tests/unit/requests/test__helpers.py
+++ b/tests/unit/requests/test__helpers.py
@@ -14,7 +14,7 @@
 
 import http.client
 
-import mock
+from unittest import mock
 import pytest  # type: ignore
 
 import requests.exceptions

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -15,7 +15,7 @@
 import http.client
 import io
 
-import mock
+from unittest import mock
 import pytest  # type: ignore
 
 from google.resumable_media import common

--- a/tests/unit/requests/test_upload.py
+++ b/tests/unit/requests/test_upload.py
@@ -16,7 +16,7 @@ import http.client
 import io
 import json
 
-import mock
+from unittest import mock
 
 import google.resumable_media.requests.upload as upload_mod
 

--- a/tests/unit/test__download.py
+++ b/tests/unit/test__download.py
@@ -15,7 +15,7 @@
 import http.client
 import io
 
-import mock
+from unittest import mock
 import pytest  # type: ignore
 
 from google.resumable_media import _download

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import hashlib
 import http.client
 
-import mock
+from unittest import mock
 import pytest  # type: ignore
 
 from google.resumable_media import _helpers

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -16,7 +16,7 @@ import http.client
 import io
 import sys
 
-import mock
+from unittest import mock
 import pytest  # type: ignore
 
 from google.resumable_media import _helpers

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import pytest  # type: ignore
 
 from google.resumable_media import common


### PR DESCRIPTION
The `mock` module is deprecated in recent Python versions.

Signed-off-by: Major Hayden <major@mhtx.net>

Fixes #328 🦕
