### PR TITLE
fix: add a check for partial response data

### DIFF
--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -44,6 +44,14 @@ Error writing to stream while handling a gzip-compressed file download.
 Please restart the download.
 """
 
+_RESPONSE_HEADERS_INFO = """\
+
+The X-Goog-Stored-Content-Length is {}. The X-Goog-Stored-Content-Encoding is {}.
+
+The download request read {} bytes of data.
+If the download was incomplete, please check the network connection and restart the download.
+"""
+
 
 class Download(_request_helpers.RequestsMixin, _download.Download):
     """Helper to manage downloading a resource from a Google API.
@@ -138,6 +146,13 @@ class Download(_request_helpers.RequestsMixin, _download.Download):
                     actual_checksum,
                     checksum_type=self.checksum.upper(),
                 )
+                headers = self._get_headers(response)
+                x_goog_encoding = headers.get("x-goog-stored-content-encoding")
+                x_goog_length = headers.get("x-goog-stored-content-length")
+                add_msg = _RESPONSE_HEADERS_INFO.format(
+                    x_goog_length, x_goog_encoding, self._bytes_downloaded
+                )
+                msg += add_msg
                 raise common.DataCorruption(response, msg)
 
     def consume(
@@ -327,6 +342,13 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
                     actual_checksum,
                     checksum_type=self.checksum.upper(),
                 )
+                headers = self._get_headers(response)
+                x_goog_encoding = headers.get("x-goog-stored-content-encoding")
+                x_goog_length = headers.get("x-goog-stored-content-length")
+                add_msg = _RESPONSE_HEADERS_INFO.format(
+                    x_goog_length, x_goog_encoding, self._bytes_downloaded
+                )
+                msg += add_msg
                 raise common.DataCorruption(response, msg)
 
     def consume(

--- a/tests/system/requests/test_download.py
+++ b/tests/system/requests/test_download.py
@@ -460,7 +460,7 @@ class TestRawDownload(TestDownload):
                 info[checksum],
                 checksum_type=checksum.upper(),
             )
-            assert exc_info.value.args == (msg,)
+            assert msg in exc_info.value.args[0]
 
     def test_corrupt_download_no_check(self, add_files, corrupting_transport):
         for info in ALL_FILES:

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -105,7 +105,11 @@ class TestDownload(object):
         msg = download_mod._CHECKSUM_MISMATCH.format(
             EXAMPLE_URL, bad_checksum, good_checksum, checksum_type=checksum.upper()
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
+        assert (
+            f"The download request read {download._bytes_downloaded} bytes of data."
+            in error.args[0]
+        )
 
         # Check mocks.
         response.__enter__.assert_called_once_with()
@@ -285,7 +289,11 @@ class TestDownload(object):
         msg = download_mod._CHECKSUM_MISMATCH.format(
             EXAMPLE_URL, bad_checksum, good_checksum, checksum_type=checksum.upper()
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
+        assert (
+            f"The download request read {download._bytes_downloaded} bytes of data."
+            in error.args[0]
+        )
 
         # Check mocks.
         transport.request.assert_called_once_with(
@@ -544,7 +552,11 @@ class TestRawDownload(object):
         msg = download_mod._CHECKSUM_MISMATCH.format(
             EXAMPLE_URL, bad_checksum, good_checksum, checksum_type=checksum.upper()
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
+        assert (
+            f"The download request read {download._bytes_downloaded} bytes of data."
+            in error.args[0]
+        )
 
         # Check mocks.
         response.__enter__.assert_called_once_with()
@@ -699,7 +711,11 @@ class TestRawDownload(object):
         msg = download_mod._CHECKSUM_MISMATCH.format(
             EXAMPLE_URL, bad_checksum, good_checksum, checksum_type=checksum.upper()
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
+        assert (
+            f"The download request read {download._bytes_downloaded} bytes of data."
+            in error.args[0]
+        )
 
         # Check mocks.
         transport.request.assert_called_once_with(

--- a/tests_async/unit/requests/test_download.py
+++ b/tests_async/unit/requests/test_download.py
@@ -98,7 +98,7 @@ class TestDownload(object):
             good_checksum,
             checksum_type=checksum.upper(),
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("checksum", ["md5", "crc32c"])
@@ -263,7 +263,7 @@ class TestDownload(object):
             good_checksum,
             checksum_type=checksum.upper(),
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
 
         # Check mocks.
         transport.request.assert_called_once_with(
@@ -353,7 +353,7 @@ class TestRawDownload(object):
             good_checksum,
             checksum_type=checksum.upper(),
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
 
     @pytest.mark.asyncio
     async def test__write_to_stream_with_invalid_checksum_type(self):
@@ -482,7 +482,7 @@ class TestRawDownload(object):
             good_checksum,
             checksum_type=checksum.upper(),
         )
-        assert error.args[0] == msg
+        assert msg in error.args[0]
 
         # Check mocks.
         transport.request.assert_called_once_with(


### PR DESCRIPTION
Handle corner cases of incomplete downloads with a 200 response code. These are rare cases when a download is prematurely terminated due to network stability or bandwidth throttling etc, but does not result in connection reset errors. The library will 
- (1) compare the # bytes read vs x-goog-stored-content-length header
- (2) raise a retry-able ConnectionError in the aim to trigger a retry

Add more context to checksum mismatch error message that will help with debugging
- bytes read from the download request (tracked within the Download object)
- `X-Goog-Stored-Content-Length` value from the response header
- `X-Goog-Stored-Content-Encoding` value from the response header


Fixes internal b/278011003
