### PR TITLE
chore: librarian release pull request: 20251111T145430Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-resumable-media
-    version: 2.7.2
+    version: 2.8.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 [1]: https://pypi.org/project/google-resumable-media/#history
 
+## [2.8.0](https://github.com/googleapis/google-cloud-python/compare/google-resumable-media-v2.7.2...google-resumable-media-v2.8.0) (2025-11-11)
+
+
+### Features
+
+* Add support for Python 3.13 and 3.14 (#485) ([9937233ded26924179d717b69df7c76c93f8c133](https://github.com/googleapis/google-cloud-python/commit/9937233ded26924179d717b69df7c76c93f8c133))
+
+
+### Bug Fixes
+
+* remove setup.cfg configuration for creating universal wheels (#484) ([75dbecf8d140483da27dffc970e2e87338e71432](https://github.com/googleapis/google-cloud-python/commit/75dbecf8d140483da27dffc970e2e87338e71432))
+* resolve issue where pre-release versions of dependencies are installed (#481) ([23dafcf3f216a090a0d0c6941048c7da13cbe496](https://github.com/googleapis/google-cloud-python/commit/23dafcf3f216a090a0d0c6941048c7da13cbe496))
+
 ## [2.7.2](https://github.com/googleapis/google-resumable-media-python/compare/v2.7.1...v2.7.2) (2024-08-07)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ EXTRAS_REQUIRE = {
 
 setuptools.setup(
     name='google-resumable-media',
-    version = "2.7.2",
+    version = "2.8.0",
     description='Utilities for Google Media Downloads and Resumable Uploads',
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.1-0.20251108121427-a138f6a0397e
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-resumable-media: 2.8.0</summary>

## [2.8.0](https://github.com/googleapis/google-resumable-media-python/compare/v2.7.2...v2.8.0) (2025-11-11)

### Features

* Add support for Python 3.13 and 3.14 (#485) ([9937233d](https://github.com/googleapis/google-resumable-media-python/commit/9937233d))

### Bug Fixes

* resolve issue where pre-release versions of dependencies are installed (#481) ([23dafcf3](https://github.com/googleapis/google-resumable-media-python/commit/23dafcf3))

* remove setup.cfg configuration for creating universal wheels (#484) ([75dbecf8](https://github.com/googleapis/google-resumable-media-python/commit/75dbecf8))

</details>