### PR TITLE
chore: librarian release pull request: 20251120T142940Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-resumable-media
-    version: 2.8.0
+    version: 2.9.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-resumable-media/#history
 
+## [2.9.0](https://github.com/googleapis/google-cloud-python/compare/google-resumable-media-v2.8.0...google-resumable-media-v2.9.0) (2025-11-20)
+
+
+### Features
+
+* some feature ([2dcf01d924fe4e36d776dd9d952146ea8c70daf5](https://github.com/googleapis/google-cloud-python/commit/2dcf01d924fe4e36d776dd9d952146ea8c70daf5))
+
 ## [2.8.0](https://github.com/googleapis/google-cloud-python/compare/google-resumable-media-v2.7.2...google-resumable-media-v2.8.0) (2025-11-11)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ EXTRAS_REQUIRE = {
 
 setuptools.setup(
     name='google-resumable-media',
-    version = "2.8.0",
+    version = "2.9.0",
     description='Utilities for Google Media Downloads and Resumable Uploads',
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-resumable-media: 2.9.0</summary>

## [2.9.0](https://github.com/googleapis/google-resumable-media-python/compare/v2.8.0...v2.9.0) (2025-11-20)

### Features

* some feature ([2dcf01d9](https://github.com/googleapis/google-resumable-media-python/commit/2dcf01d9))

</details>