### PR TITLE
fix: add max_length support to Gzip/Brotli decoders for urllib3 v2.6+ compatibility

### DIFF
--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -667,17 +667,24 @@ class _GzipDecoder(urllib3.response.GzipDecoder):
         super().__init__()
         self._checksum = checksum
 
-    def decompress(self, data):
+    def decompress(self, data, max_length=None):
         """Decompress the bytes.
 
         Args:
             data (bytes): The compressed bytes to be decompressed.
+            max_length (optional[int]): The maximum number of bytes to decompress.
+                This parameter is required for compatibility with urllib3>=2.6.0
+                and is passed to the underlying urllib3 decoder.
 
         Returns:
             bytes: The decompressed bytes from ``data``.
         """
         self._checksum.update(data)
-        return super().decompress(data)
+        try:
+            return super().decompress(data, max_length=max_length)
+        except TypeError:
+            # FB for urllib3 <2.6.0
+            return super().decompress(data)
 
 
 # urllib3.response.BrotliDecoder might not exist depending on whether brotli is
@@ -703,17 +710,24 @@ if hasattr(urllib3.response, "BrotliDecoder"):
             self._decoder = urllib3.response.BrotliDecoder()
             self._checksum = checksum
 
-        def decompress(self, data):
+        def decompress(self, data, max_length=None):
             """Decompress the bytes.
 
             Args:
                 data (bytes): The compressed bytes to be decompressed.
+                max_length (optional[int]): The maximum number of bytes to decompress.
+                This parameter is required for compatibility with urllib3>=2.6.0
+                and is passed to the underlying urllib3 decoder.
 
             Returns:
                 bytes: The decompressed bytes from ``data``.
             """
             self._checksum.update(data)
-            return self._decoder.decompress(data)
+            try:
+                return self._decoder.decompress(data, max_length=max_length)
+            except TypeError:
+                # FB for urllib3 <2.6.0
+                return self._decoder.decompress(data)
 
         def flush(self):
             return self._decoder.flush()

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -667,7 +667,7 @@ class _GzipDecoder(urllib3.response.GzipDecoder):
         super().__init__()
         self._checksum = checksum
 
-    def decompress(self, data, max_length=None):
+    def decompress(self, data, max_length=-1):
         """Decompress the bytes.
 
         Args:
@@ -685,6 +685,11 @@ class _GzipDecoder(urllib3.response.GzipDecoder):
         except TypeError:
             # FB for urllib3 <2.6.0
             return super().decompress(data)
+
+    @property
+    def has_unconsumed_tail(self) -> bool:
+        # Checks for buffered, unread bytes
+        return self._decoder.has_unconsumed_tail
 
 
 # urllib3.response.BrotliDecoder might not exist depending on whether brotli is
@@ -710,7 +715,7 @@ if hasattr(urllib3.response, "BrotliDecoder"):
             self._decoder = urllib3.response.BrotliDecoder()
             self._checksum = checksum
 
-        def decompress(self, data, max_length=None):
+        def decompress(self, data, max_length=-1):
             """Decompress the bytes.
 
             Args:
@@ -731,6 +736,11 @@ if hasattr(urllib3.response, "BrotliDecoder"):
 
         def flush(self):
             return self._decoder.flush()
+        
+        @property
+        def has_unconsumed_tail(self) -> bool:
+            # Checks for buffered, unread bytes
+            return self._decoder.has_unconsumed_tail
 
 else:  # pragma: NO COVER
     _BrotliDecoder = None  # type: ignore # pragma: NO COVER


### PR DESCRIPTION
Fixes #491 

Adds the required `max_length=None` parameter to decoder methods to maintain compatibility with `urllib3 >= 2.6.0`.